### PR TITLE
Set default value for `virtualServerName` in Swagger docs

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -66,6 +66,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "keyline",
                         "description": "Virtual server name",
                         "name": "virtualServerName",
                         "in": "path",
@@ -100,6 +101,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "keyline",
                         "description": "Virtual server name",
                         "name": "virtualServerName",
                         "in": "path",
@@ -128,6 +130,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "keyline",
                         "description": "Virtual server name",
                         "name": "virtualServerName",
                         "in": "path",
@@ -168,6 +171,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "keyline",
                         "description": "Virtual server name",
                         "name": "virtualServerName",
                         "in": "path",
@@ -239,6 +243,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "keyline",
                         "description": "Virtual server name",
                         "name": "virtualServerName",
                         "in": "path",
@@ -288,6 +293,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "keyline",
                         "description": "Virtual server name",
                         "name": "virtualServerName",
                         "in": "path",
@@ -341,6 +347,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "keyline",
                         "description": "Virtual server name",
                         "name": "virtualServerName",
                         "in": "path",
@@ -397,6 +404,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "keyline",
                         "description": "Virtual server name",
                         "name": "virtualServerName",
                         "in": "path",
@@ -431,6 +439,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "keyline",
                         "description": "Virtual server name",
                         "name": "virtualServerName",
                         "in": "path",
@@ -472,6 +481,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "keyline",
                         "description": "Virtual server name",
                         "name": "virtualServerName",
                         "in": "path",
@@ -527,6 +537,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "keyline",
                         "description": "Virtual server name",
                         "name": "virtualServerName",
                         "in": "path",
@@ -570,6 +581,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "keyline",
                         "description": "Virtual server name",
                         "name": "virtualServerName",
                         "in": "path",
@@ -611,6 +623,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "keyline",
                         "description": "Virtual server name",
                         "name": "virtualServerName",
                         "in": "path",
@@ -653,6 +666,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "keyline",
                         "description": "Virtual server name",
                         "name": "virtualServerName",
                         "in": "path",
@@ -707,7 +721,8 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Virtual Server Name",
+                        "default": "keyline",
+                        "description": "Virtual server name",
                         "name": "vsName",
                         "in": "path",
                         "required": true
@@ -773,7 +788,8 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Virtual Server Name",
+                        "default": "keyline",
+                        "description": "Virtual server name",
                         "name": "vsName",
                         "in": "path",
                         "required": true
@@ -820,7 +836,8 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Virtual Server Name",
+                        "default": "keyline",
+                        "description": "Virtual server name",
                         "name": "vsName",
                         "in": "path",
                         "required": true
@@ -1213,6 +1230,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "keyline",
                         "description": "Virtual server name",
                         "name": "virtualServerName",
                         "in": "path",
@@ -1253,6 +1271,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "keyline",
                         "description": "Virtual server name",
                         "name": "virtualServerName",
                         "in": "path",
@@ -1291,6 +1310,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "keyline",
                         "description": "Virtual server name",
                         "name": "virtualServerName",
                         "in": "path",
@@ -1383,6 +1403,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "keyline",
                         "description": "Virtual server name",
                         "name": "virtualServerName",
                         "in": "path",
@@ -1473,6 +1494,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "keyline",
                         "description": "Virtual server name",
                         "name": "virtualServerName",
                         "in": "path",
@@ -1591,6 +1613,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "keyline",
                         "description": "Virtual server name",
                         "name": "virtualServerName",
                         "in": "path",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -58,6 +58,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "keyline",
                         "description": "Virtual server name",
                         "name": "virtualServerName",
                         "in": "path",
@@ -92,6 +93,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "keyline",
                         "description": "Virtual server name",
                         "name": "virtualServerName",
                         "in": "path",
@@ -120,6 +122,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "keyline",
                         "description": "Virtual server name",
                         "name": "virtualServerName",
                         "in": "path",
@@ -160,6 +163,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "keyline",
                         "description": "Virtual server name",
                         "name": "virtualServerName",
                         "in": "path",
@@ -231,6 +235,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "keyline",
                         "description": "Virtual server name",
                         "name": "virtualServerName",
                         "in": "path",
@@ -280,6 +285,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "keyline",
                         "description": "Virtual server name",
                         "name": "virtualServerName",
                         "in": "path",
@@ -333,6 +339,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "keyline",
                         "description": "Virtual server name",
                         "name": "virtualServerName",
                         "in": "path",
@@ -389,6 +396,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "keyline",
                         "description": "Virtual server name",
                         "name": "virtualServerName",
                         "in": "path",
@@ -423,6 +431,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "keyline",
                         "description": "Virtual server name",
                         "name": "virtualServerName",
                         "in": "path",
@@ -464,6 +473,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "keyline",
                         "description": "Virtual server name",
                         "name": "virtualServerName",
                         "in": "path",
@@ -519,6 +529,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "keyline",
                         "description": "Virtual server name",
                         "name": "virtualServerName",
                         "in": "path",
@@ -562,6 +573,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "keyline",
                         "description": "Virtual server name",
                         "name": "virtualServerName",
                         "in": "path",
@@ -603,6 +615,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "keyline",
                         "description": "Virtual server name",
                         "name": "virtualServerName",
                         "in": "path",
@@ -645,6 +658,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "keyline",
                         "description": "Virtual server name",
                         "name": "virtualServerName",
                         "in": "path",
@@ -699,7 +713,8 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Virtual Server Name",
+                        "default": "keyline",
+                        "description": "Virtual server name",
                         "name": "vsName",
                         "in": "path",
                         "required": true
@@ -765,7 +780,8 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Virtual Server Name",
+                        "default": "keyline",
+                        "description": "Virtual server name",
                         "name": "vsName",
                         "in": "path",
                         "required": true
@@ -812,7 +828,8 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Virtual Server Name",
+                        "default": "keyline",
+                        "description": "Virtual server name",
                         "name": "vsName",
                         "in": "path",
                         "required": true
@@ -1205,6 +1222,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "keyline",
                         "description": "Virtual server name",
                         "name": "virtualServerName",
                         "in": "path",
@@ -1245,6 +1263,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "keyline",
                         "description": "Virtual server name",
                         "name": "virtualServerName",
                         "in": "path",
@@ -1283,6 +1302,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "keyline",
                         "description": "Virtual server name",
                         "name": "virtualServerName",
                         "in": "path",
@@ -1375,6 +1395,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "keyline",
                         "description": "Virtual server name",
                         "name": "virtualServerName",
                         "in": "path",
@@ -1465,6 +1486,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "keyline",
                         "description": "Virtual server name",
                         "name": "virtualServerName",
                         "in": "path",
@@ -1583,6 +1605,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "keyline",
                         "description": "Virtual server name",
                         "name": "virtualServerName",
                         "in": "path",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -480,7 +480,8 @@ paths:
   /api/virtual-servers/{virtualServerName}:
     get:
       parameters:
-      - description: Virtual server name
+      - default: keyline
+        description: Virtual server name
         in: path
         name: virtualServerName
         required: true
@@ -502,7 +503,8 @@ paths:
   /api/virtual-servers/{virtualServerName}/health:
     get:
       parameters:
-      - description: Virtual server name
+      - default: keyline
+        description: Virtual server name
         in: path
         name: virtualServerName
         required: true
@@ -520,7 +522,8 @@ paths:
   /api/virtual-servers/{virtualServerName}/public-info:
     get:
       parameters:
-      - description: Virtual server name
+      - default: keyline
+        description: Virtual server name
         in: path
         name: virtualServerName
         required: true
@@ -543,7 +546,8 @@ paths:
     get:
       description: Retrieve a paginated list of roles within a virtual server.
       parameters:
-      - description: Virtual server name
+      - default: keyline
+        description: Virtual server name
         in: path
         name: virtualServerName
         required: true
@@ -589,7 +593,8 @@ paths:
       - application/json
       description: Create a new role within a virtual server.
       parameters:
-      - description: Virtual server name
+      - default: keyline
+        description: Virtual server name
         in: path
         name: virtualServerName
         required: true
@@ -620,7 +625,8 @@ paths:
     get:
       description: Get a role by its ID within a virtual server.
       parameters:
-      - description: Virtual server name
+      - default: keyline
+        description: Virtual server name
         in: path
         name: virtualServerName
         required: true
@@ -656,7 +662,8 @@ paths:
       - application/json
       description: Assign an existing role to a user within a virtual server.
       parameters:
-      - description: Virtual server name
+      - default: keyline
+        description: Virtual server name
         in: path
         name: virtualServerName
         required: true
@@ -693,7 +700,8 @@ paths:
   /api/virtual-servers/{virtualServerName}/templates:
     get:
       parameters:
-      - description: Virtual server name
+      - default: keyline
+        description: Virtual server name
         in: path
         name: virtualServerName
         required: true
@@ -715,7 +723,8 @@ paths:
   /api/virtual-servers/{virtualServerName}/templates/{templateType}:
     get:
       parameters:
-      - description: Virtual server name
+      - default: keyline
+        description: Virtual server name
         in: path
         name: virtualServerName
         required: true
@@ -742,7 +751,8 @@ paths:
   /api/virtual-servers/{virtualServerName}/users:
     get:
       parameters:
-      - description: Virtual server name
+      - default: keyline
+        description: Virtual server name
         in: path
         name: virtualServerName
         required: true
@@ -776,7 +786,8 @@ paths:
   /api/virtual-servers/{virtualServerName}/users/{userId}:
     get:
       parameters:
-      - description: Virtual server name
+      - default: keyline
+        description: Virtual server name
         in: path
         name: virtualServerName
         required: true
@@ -804,7 +815,8 @@ paths:
       consumes:
       - application/json
       parameters:
-      - description: Virtual server name
+      - default: keyline
+        description: Virtual server name
         in: path
         name: virtualServerName
         required: true
@@ -839,7 +851,8 @@ paths:
       consumes:
       - application/json
       parameters:
-      - description: Virtual server name
+      - default: keyline
+        description: Virtual server name
         in: path
         name: virtualServerName
         required: true
@@ -867,7 +880,8 @@ paths:
   /api/virtual-servers/{virtualServerName}/users/verify-email:
     get:
       parameters:
-      - description: Virtual server name
+      - default: keyline
+        description: Virtual server name
         in: path
         name: virtualServerName
         required: true
@@ -897,7 +911,8 @@ paths:
       - application/json
       description: Retrieve a paginated list of applications (OIDC clients)
       parameters:
-      - description: Virtual Server Name
+      - default: keyline
+        description: Virtual server name
         in: path
         name: vsName
         required: true
@@ -941,7 +956,8 @@ paths:
       - application/json
       description: Create a new OIDC application/client with redirect URIs and type
       parameters:
-      - description: Virtual Server Name
+      - default: keyline
+        description: Virtual server name
         in: path
         name: vsName
         required: true
@@ -972,7 +988,8 @@ paths:
       - application/json
       description: Get an application by ID from a virtual server
       parameters:
-      - description: Virtual Server Name
+      - default: keyline
+        description: Virtual server name
         in: path
         name: vsName
         required: true
@@ -1229,7 +1246,8 @@ paths:
       description: Returns the public keys used to verify tokens for this virtual
         server.
       parameters:
-      - description: Virtual server name
+      - default: keyline
+        description: Virtual server name
         in: path
         name: virtualServerName
         required: true
@@ -1255,7 +1273,8 @@ paths:
   /oidc/{virtualServerName}/.well-known/openid-configuration:
     get:
       parameters:
-      - description: Virtual server name
+      - default: keyline
+        description: Virtual server name
         in: path
         name: virtualServerName
         required: true
@@ -1282,7 +1301,8 @@ paths:
         redirects to your login UI; otherwise redirects to the application's redirect_uri
         with an authorization code.
       parameters:
-      - description: Virtual server name
+      - default: keyline
+        description: Virtual server name
         in: path
         name: virtualServerName
         required: true
@@ -1347,7 +1367,8 @@ paths:
         redirects to your login UI; otherwise redirects to the application's redirect_uri
         with an authorization code.
       parameters:
-      - description: Virtual server name
+      - default: keyline
+        description: Virtual server name
         in: path
         name: virtualServerName
         required: true
@@ -1408,7 +1429,8 @@ paths:
   /oidc/{virtualServerName}/end_session:
     get:
       parameters:
-      - description: Virtual server name
+      - default: keyline
+        description: Virtual server name
         in: path
         name: virtualServerName
         required: true
@@ -1481,7 +1503,8 @@ paths:
   /oidc/{virtualServerName}/userinfo:
     get:
       parameters:
-      - description: Virtual server name
+      - default: keyline
+        description: Virtual server name
         in: path
         name: virtualServerName
         required: true

--- a/handlers/applications.go
+++ b/handlers/applications.go
@@ -34,7 +34,7 @@ type CreateApplicationResponseDto struct {
 // @Tags applications
 // @Accept json
 // @Produce json
-// @Param vsName path string true "Virtual Server Name"
+// @Param vsName path string true "Virtual server name"  default(keyline)
 // @Param request body CreateApplicationRequestDto true "Application data"
 // @Success 201 {object} CreateApplicationResponseDto
 // @Failure 400
@@ -106,7 +106,7 @@ type GetApplicationResponseDto struct {
 // @Tags applications
 // @Accept json
 // @Produce json
-// @Param vsName path string true "Virtual Server Name"
+// @Param vsName path string true "Virtual server name"  default(keyline)
 // @Param appId path string true "Application ID (UUID)"
 // @Success 200 {object} GetApplicationResponseDto
 // @Failure 400
@@ -179,7 +179,7 @@ type ListApplicationsResponseDto struct {
 // @Tags applications
 // @Accept json
 // @Produce json
-// @Param vsName path string true "Virtual Server Name"
+// @Param vsName path string true "Virtual server name"  default(keyline)
 // @Param page query int false "Page number"
 // @Param pageSize query int false "Page size"
 // @Param orderBy query string false "Order by field"

--- a/handlers/health.go
+++ b/handlers/health.go
@@ -16,7 +16,7 @@ func ApplicationHealth(w http.ResponseWriter, r *http.Request) {
 // @Summary     Virtual server health
 // @Tags        System
 // @Produce     plain
-// @Param       virtualServerName path string true "Virtual server name"
+// @Param       virtualServerName path string true "Virtual server name"  default(keyline)
 // @Success     200 {string} string "OK"
 // @Router      /api/virtual-servers/{virtualServerName}/health [get]
 func VirtualServerHealth(w http.ResponseWriter, r *http.Request) {

--- a/handlers/oidc.go
+++ b/handlers/oidc.go
@@ -61,7 +61,7 @@ func trimLeadingZeros(b []byte) []byte {
 // @Description  Returns the public keys used to verify tokens for this virtual server.
 // @Tags         OIDC
 // @Produce      json
-// @Param        virtualServerName  path  string  true  "Virtual server name"
+// @Param        virtualServerName  path  string  true  "Virtual server name"  default(keyline)
 // @Success      200  {object}  handlers.JwksResponseDto
 // @Failure      400  {string}  string
 // @Failure      500  {string}  string
@@ -159,7 +159,7 @@ type OpenIdConfigurationResponseDto struct {
 // @Summary      OpenID Provider configuration
 // @Tags         OIDC
 // @Produce      json
-// @Param        virtualServerName  path  string  true  "Virtual server name"
+// @Param        virtualServerName  path  string  true  "Virtual server name"  default(keyline)
 // @Success      200  {object}  handlers.OpenIdConfigurationResponseDto
 // @Failure      400  {string}  string
 // @Router       /oidc/{virtualServerName}/.well-known/openid-configuration [get]
@@ -215,7 +215,7 @@ type AuthorizationRequest struct {
 // @Tags         OIDC
 // @Produce      plain
 // @Accept       application/x-www-form-urlencoded
-// @Param        virtualServerName      path     string true   "Virtual server name"
+// @Param        virtualServerName      path     string true   "Virtual server name"  default(keyline)
 // @Param        response_type          query    string true   "Must be 'code'"
 // @Param        client_id              query    string true   "Application (client) ID"
 // @Param        redirect_uri           query    string true   "Registered redirect URI"
@@ -389,7 +389,7 @@ func BeginAuthorizationFlow(w http.ResponseWriter, r *http.Request) {
 // @Summary      End session
 // @Tags         OIDC
 // @Produce      json
-// @Param        virtualServerName         path     string true  "Virtual server name"
+// @Param        virtualServerName         path     string true  "Virtual server name"  default(keyline)
 // @Param        id_token_hint             query    string true  "ID token hint of the current session"
 // @Param        post_logout_redirect_uri  query    string false "Where to redirect after logout (must be registered)"
 // @Param        state                     query    string false "Opaque value returned to client"
@@ -516,7 +516,7 @@ type OidcUserInfoResponseDto struct {
 // @Summary      Userinfo
 // @Tags         OIDC
 // @Produce      json
-// @Param        virtualServerName  path   string true  "Virtual server name"
+// @Param        virtualServerName  path   string true  "Virtual server name"  default(keyline)
 // @Security     BearerAuth
 // @Success      200  {object}  handlers.OidcUserInfoResponseDto
 // @Failure      401  {string}  string

--- a/handlers/roles.go
+++ b/handlers/roles.go
@@ -35,7 +35,7 @@ type GetRoleByIdResponseDto struct {
 // @description Get a role by its ID within a virtual server.
 // @tags        Roles
 // @produce     application/json
-// @param       virtualServerName  path  string  true  "Virtual server name"
+// @param       virtualServerName  path  string  true  "Virtual server name"  default(keyline)
 // @param       roleId             path  string  true  "Role ID (UUID)"
 // @security    BearerAuth
 // @success     200  {object}  handlers.GetRoleByIdResponseDto
@@ -101,7 +101,7 @@ type ListRolesResponseDto struct {
 // @description Retrieve a paginated list of roles within a virtual server.
 // @tags        Roles
 // @produce     application/json
-// @param       virtualServerName  path   string  true  "Virtual server name"
+// @param       virtualServerName  path   string  true  "Virtual server name"  default(keyline)
 // @param       page               query  int     false "Page number"
 // @param       pageSize           query  int     false "Page size"
 // @param       orderBy            query  string  false "Order by field (e.g., name, createdAt)"
@@ -177,7 +177,7 @@ type CreateRoleResponseDto struct {
 // @tags        Roles
 // @accept      application/json
 // @produce     application/json
-// @param       virtualServerName  path   string                         true  "Virtual server name"
+// @param       virtualServerName  path   string                         true  "Virtual server name"  default(keyline)
 // @param       body               body   handlers.CreateRoleRequestDto  true  "Role data"
 // @security    BearerAuth
 // @success     201  {object}  handlers.CreateRoleResponseDto
@@ -239,7 +239,7 @@ type AssignRoleRequestDto struct {
 // @description Assign an existing role to a user within a virtual server.
 // @tags        Roles
 // @accept      application/json
-// @param       virtualServerName  path   string                          true  "Virtual server name"
+// @param       virtualServerName  path   string                          true  "Virtual server name"  default(keyline)
 // @param       roleId             path   string                          true  "Role ID (UUID)"
 // @param       body               body   handlers.AssignRoleRequestDto   true  "Assignment data"
 // @security    BearerAuth

--- a/handlers/templates.go
+++ b/handlers/templates.go
@@ -32,7 +32,7 @@ type GetTemplateResponseDto struct {
 // @Summary      Get template
 // @Tags         Templates
 // @Produce      json
-// @Param        virtualServerName  path   string true  "Virtual server name"
+// @Param        virtualServerName  path   string true  "Virtual server name"  default(keyline)
 // @Param        templateType       path   string true  "Template type"
 // @Success      200  {object}  GetTemplateResponseDto
 // @Failure      404  {string}  string
@@ -91,7 +91,7 @@ type ListTemplatesResponseDto struct {
 // @Summary      List templates
 // @Tags         Templates
 // @Produce      json
-// @Param        virtualServerName  path   string true  "Virtual server name"
+// @Param        virtualServerName  path   string true  "Virtual server name"  default(keyline)
 // @Success      200  {object}  PagedTemplatesResponseDto
 // @Failure      400  {string} string
 // @Router       /api/virtual-servers/{virtualServerName}/templates [get]

--- a/handlers/users.go
+++ b/handlers/users.go
@@ -32,7 +32,7 @@ var (
 // @Summary      Verify email
 // @Tags         Users
 // @Produce      plain
-// @Param        virtualServerName  path   string true  "Virtual server name"
+// @Param        virtualServerName  path   string true  "Virtual server name"  default(keyline)
 // @Param        token              query  string true  "Verification token"
 // @Success      302  {string} string "Redirect to frontend confirmation page"
 // @Failure      400  {string} string
@@ -70,7 +70,7 @@ func VerifyEmail(w http.ResponseWriter, r *http.Request) {
 // @Tags         Users
 // @Accept       json
 // @Produce      plain
-// @Param        virtualServerName  path  string                   true "Virtual server name"
+// @Param        virtualServerName  path  string                   true "Virtual server name"  default(keyline)
 // @Param        body               body  RegisterUserRequestDto   true "User data"
 // @Success      204                {string} string "No Content"
 // @Failure      400                {string} string
@@ -130,7 +130,7 @@ type PagedUsersResponseDto struct {
 // @Summary      List users
 // @Tags         Users
 // @Produce      json
-// @Param        virtualServerName  path   string true  "Virtual server name"
+// @Param        virtualServerName  path   string true  "Virtual server name"  default(keyline)
 // @Param        page               query  int    false "Page number"
 // @Param        pageSize           query  int    false "Page size"
 // @Param        search             query  string false "Search term"
@@ -202,7 +202,7 @@ type GetUserByIdResponseDto struct {
 // @Summary      Get user
 // @Tags         Users
 // @Produce      json
-// @Param        virtualServerName  path  string true  "Virtual server name"
+// @Param        virtualServerName  path  string true  "Virtual server name"  default(keyline)
 // @Param        userId             path  string true  "User ID (UUID)"
 // @Success      200  {object}  GetUserByIdResponseDto
 // @Failure      404  {string}  string
@@ -265,7 +265,7 @@ type PatchUserRequestDto struct {
 // @Tags         Users
 // @Accept       json
 // @Produce      plain
-// @Param        virtualServerName  path  string                true "Virtual server name"
+// @Param        virtualServerName  path  string                true "Virtual server name"  default(keyline)
 // @Param        userId             path  string                true "User ID (UUID)"
 // @Param        body               body  PatchUserRequestDto   true "Patch document"
 // @Success      204  {string} string "No Content"

--- a/handlers/virtualServers.go
+++ b/handlers/virtualServers.go
@@ -86,7 +86,7 @@ type GetVirtualServerResponseDto struct {
 // @Summary      Get virtual server
 // @Tags         Admin
 // @Produce      json
-// @Param        virtualServerName  path  string  true  "Virtual server name"
+// @Param        virtualServerName  path  string  true  "Virtual server name"  default(keyline)
 // @Success      200  {object}  handlers.GetVirtualServerResponseDto
 // @Failure      404  {string}  string
 // @Router       /api/virtual-servers/{virtualServerName} [get]
@@ -138,7 +138,7 @@ type GetVirtualServerListResponseDto struct {
 // @Summary      Get virtual server public info
 // @Tags         Admin
 // @Produce      json
-// @Param        virtualServerName  path  string  true  "Virtual server name"
+// @Param        virtualServerName  path  string  true  "Virtual server name"  default(keyline)
 // @Success      200  {object}  handlers.GetVirtualServerListResponseDto
 // @Failure      404  {string}  string
 // @Router       /api/virtual-servers/{virtualServerName}/public-info [get]


### PR DESCRIPTION
Added default value for `virtualServerName` keyline in Swagger documentation to avoid having to improve the user experience