### PR TITLE
ci: conditionally run commit sign-off check on `main` branch

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,6 +14,7 @@ jobs:
   signoff:
     name: Check commit sign-offs
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.base_ref == 'main'
     steps:
       - name: Checkout code
         uses: actions/checkout@v5


### PR DESCRIPTION
Added a condition to execute the commit sign-off check workflow only for the `main` branch.