### PR TITLE
Correct typo in Keyline description

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Go Version](https://img.shields.io/badge/Go-1.24-00ADD8?logo=go)](https://go.dev/)
 [![Go CI](https://github.com/The127/Keyline/actions/workflows/go.yml/badge.svg)](https://github.com/The127/Keyline/actions/workflows/go.yml)
 
-**Keyline** is an open-source OpenID Connect (OIDC) / Identity Provider (IDP) server built with Go. It providesa robust, scalable authentication and authorization solution for modern applications.
+**Keyline** is an open-source OpenID Connect (OIDC) / Identity Provider (IDP) server built with Go. It provides a robust, scalable authentication and authorization solution for modern applications.
 
 The goal is to create an open-source, self-hostable, lightweight, fast, secure, feature rich (but in a good opinionated way), easily configurable and developer friendly OIDC server.
 


### PR DESCRIPTION
Fixed a typo in the README regarding the description of Keyline.