### PR TITLE
fix: correct log condition in PolicyMiddleware

### DIFF
--- a/internal/behaviours/PolicyMiddleware.go
+++ b/internal/behaviours/PolicyMiddleware.go
@@ -150,8 +150,8 @@ func PolicyBehaviour(ctx context.Context, request Policy, next mediator.Next) (a
 
 	response, err := next()
 
-	// don't log if there was an error
-	if err == nil || !request.LogRequest() {
+	// don't log if there was an error and only log if the request says so
+	if err == nil && request.LogRequest() {
 		scope := middlewares.GetScope(ctx)
 		auditLogger := ioc.GetDependency[AuditLogger](scope)
 


### PR DESCRIPTION
Adjusted the log condition to ensure logging occurs only when there is no error and the request explicitly allows logging.