### PR TITLE
refactor: remove application-level role management from user role ass…

### DIFF
--- a/internal/authentication/AuthenticationMiddleware.go
+++ b/internal/authentication/AuthenticationMiddleware.go
@@ -132,7 +132,7 @@ func extractUserFromBearerToken(ctx context.Context, authorizationHeader string,
 
 	currentUser := NewCurrentUser(userId)
 
-	roleClaims, ok := claims["application_roles"]
+	roleClaims, ok := claims["roles"]
 	if ok {
 		roleClaimsArray, ok := roleClaims.([]any)
 		if ok {

--- a/internal/database/migrations/35_removeApplicationRoles.sql
+++ b/internal/database/migrations/35_removeApplicationRoles.sql
@@ -1,0 +1,6 @@
+-- +migrate Up
+
+alter table user_role_assignments drop column application_id;
+
+-- +migrate Down
+

--- a/internal/handlers/oidc.go
+++ b/internal/handlers/oidc.go
@@ -1209,7 +1209,6 @@ func mapClaims(ctx context.Context, params AccessTokenGenerationParams) (jwt.Map
 	globalUserRoleAssignmentFilter := repositories.NewUserRoleAssignmentFilter().
 		// TODO: add virtual server filter
 		UserId(params.UserId).
-		ApplicationId(nil).
 		IncludeRole()
 	globalUserRoleAssignments, _, err := userRoleAssignmentRepository.List(ctx, globalUserRoleAssignmentFilter)
 	if err != nil {
@@ -1224,7 +1223,6 @@ func mapClaims(ctx context.Context, params AccessTokenGenerationParams) (jwt.Map
 	applicationUserRoleAssignmentFilter := repositories.NewUserRoleAssignmentFilter().
 		// TODO: add virtual server filter
 		UserId(params.UserId).
-		ApplicationId(&params.ApplicationId).
 		IncludeRole()
 	applicationUserRoleAssignments, _, err := userRoleAssignmentRepository.List(ctx, applicationUserRoleAssignmentFilter)
 	applicationRoles := make([]string, 0, len(applicationUserRoleAssignments))

--- a/internal/repositories/postgres/userroleassignments.go
+++ b/internal/repositories/postgres/userroleassignments.go
@@ -29,7 +29,6 @@ func (r *userRoleAssignmentRepository) selectQuery(filter repositories.UserRoleA
 		"ura.user_id",
 		"ura.role_id",
 		"ura.group_id",
-		"ura.application_id",
 	).From("user_role_assignments as ura")
 
 	if filter.HasUserId() {
@@ -42,10 +41,6 @@ func (r *userRoleAssignmentRepository) selectQuery(filter repositories.UserRoleA
 
 	if filter.HasGroupId() {
 		s.Where(s.Equal("ura.group_id", filter.GetGroupId()))
-	}
-
-	if filter.HasApplicationId() {
-		s.Where(s.Equal("ura.application_id", filter.GetApplicationId()))
 	}
 
 	if filter.GetIncludeUser() {
@@ -117,13 +112,11 @@ func (r *userRoleAssignmentRepository) Insert(ctx context.Context, userRoleAssig
 			"user_id",
 			"role_id",
 			"group_id",
-			"application_id",
 		).
 		Values(
 			userRoleAssignment.UserId(),
 			userRoleAssignment.RoleId(),
 			userRoleAssignment.GroupId(),
-			userRoleAssignment.ApplicationId(),
 		).Returning("id", "audit_created_at", "audit_updated_at", "version")
 
 	query, args := s.Build()

--- a/internal/repositories/userroleassignments.go
+++ b/internal/repositories/userroleassignments.go
@@ -10,10 +10,9 @@ import (
 type UserRoleAssignment struct {
 	ModelBase
 
-	userId        uuid.UUID
-	roleId        uuid.UUID
-	groupId       *uuid.UUID
-	applicationId *uuid.UUID
+	userId  uuid.UUID
+	roleId  uuid.UUID
+	groupId *uuid.UUID
 
 	userInfo UserRoleAssignmentUserInfo
 	roleInfo UserRoleAssignmentRoleInfo
@@ -57,10 +56,6 @@ func (u *UserRoleAssignment) GroupId() *uuid.UUID {
 	return u.groupId
 }
 
-func (u *UserRoleAssignment) ApplicationId() *uuid.UUID {
-	return u.applicationId
-}
-
 func (u *UserRoleAssignment) GetScanPointers(filter UserRoleAssignmentFilter) []any {
 	ptrs := []any{
 		&u.id,
@@ -70,7 +65,6 @@ func (u *UserRoleAssignment) GetScanPointers(filter UserRoleAssignmentFilter) []
 		&u.userId,
 		&u.roleId,
 		&u.groupId,
-		&u.applicationId,
 	}
 
 	if filter.includeUser {
@@ -89,17 +83,12 @@ func (u *UserRoleAssignment) GetScanPointers(filter UserRoleAssignmentFilter) []
 	return ptrs
 }
 
-type applicationIdFilter struct {
-	value *uuid.UUID
-}
-
 type UserRoleAssignmentFilter struct {
-	userId        *uuid.UUID
-	roleId        *uuid.UUID
-	groupId       *uuid.UUID
-	applicationId *applicationIdFilter
-	includeUser   bool
-	includeRole   bool
+	userId      *uuid.UUID
+	roleId      *uuid.UUID
+	groupId     *uuid.UUID
+	includeUser bool
+	includeRole bool
 }
 
 func NewUserRoleAssignmentFilter() UserRoleAssignmentFilter {
@@ -150,22 +139,6 @@ func (f UserRoleAssignmentFilter) HasGroupId() bool {
 
 func (f UserRoleAssignmentFilter) GetGroupId() uuid.UUID {
 	return utils.ZeroIfNil(f.groupId)
-}
-
-func (f UserRoleAssignmentFilter) ApplicationId(applicationId *uuid.UUID) UserRoleAssignmentFilter {
-	filter := f.Clone()
-	filter.applicationId = &applicationIdFilter{
-		value: applicationId,
-	}
-	return filter
-}
-
-func (f UserRoleAssignmentFilter) HasApplicationId() bool {
-	return f.applicationId != nil
-}
-
-func (f UserRoleAssignmentFilter) GetApplicationId() *uuid.UUID {
-	return f.applicationId.value
 }
 
 func (f UserRoleAssignmentFilter) IncludeUser() UserRoleAssignmentFilter {


### PR DESCRIPTION
…ignments

Dropped the `application_id` field from the `UserRoleAssignment` model and relevant filters, methods, and query builders. Updated associated middleware and handlers to reflect the changes. Added a database migration to drop the `application_id` column.