### PR TITLE
fix: use standard base64 encoding for challenge decoding

### DIFF
--- a/internal/handlers/login.go
+++ b/internal/handlers/login.go
@@ -828,7 +828,7 @@ func FinishPasskeyLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	actualChallenge, err := base64.RawURLEncoding.DecodeString(challenge.Challenge)
+	actualChallenge, err := base64.StdEncoding.DecodeString(challenge.Challenge)
 	if err != nil {
 		utils.HandleHttpError(w, err)
 		return


### PR DESCRIPTION
Switched from `RawURLEncoding` to `StdEncoding` for base64 challenge decoding to ensure compatibility with expected input format and improve robustness.