### PR TITLE
feat: support updating `emailVerified` in `PatchUser` command

### DIFF
--- a/internal/commands/PatchUser.go
+++ b/internal/commands/PatchUser.go
@@ -18,6 +18,7 @@ type PatchUser struct {
 	VirtualServerName string
 	UserId            uuid.UUID
 	DisplayName       *string
+	EmailVerified     *bool
 }
 
 func (a PatchUser) LogRequest() bool {
@@ -56,6 +57,10 @@ func HandlePatchUser(ctx context.Context, command PatchUser) (*PatchUserResponse
 
 	if command.DisplayName != nil {
 		user.SetDisplayName(*command.DisplayName)
+	}
+
+	if command.EmailVerified != nil {
+		user.SetEmailVerified(*command.EmailVerified)
 	}
 
 	dbContext.Users().Update(user)

--- a/internal/handlers/users.go
+++ b/internal/handlers/users.go
@@ -772,7 +772,8 @@ func PatchUserApplicationMetadata(w http.ResponseWriter, r *http.Request) {
 }
 
 type PatchUserRequestDto struct {
-	DisplayName *string `json:"displayName"`
+	DisplayName   *string `json:"displayName"`
+	EmailVerified *bool   `json:"emailVerified"`
 }
 
 // PatchUser updates fields of a user.
@@ -816,6 +817,7 @@ func PatchUser(w http.ResponseWriter, r *http.Request) {
 		UserId:            userId,
 		VirtualServerName: vsName,
 		DisplayName:       utils.TrimSpace(dto.DisplayName),
+		EmailVerified:     dto.EmailVerified,
 	}
 	_, err = mediatr.Send[*commands.PatchUserResponse](ctx, m, command)
 	if err != nil {


### PR DESCRIPTION
Extended `PatchUser` command, DTO, and handler to allow updating the `emailVerified` field for user entities.