### PR TITLE
feat: add endpoints to list and delete active sessions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,13 +37,3 @@ services:
     ports:
       - "5672:5672"
       - "15672:15672"
-
-  keyline-ui:
-    image: ghcr.io/the127/keyline-ui:v0.1.4
-    platform: linux/amd64
-    container_name: keyline-ui
-    ports: ["5173:80"]
-    environment:
-      KEYLINE_API_URL: "http://localhost:8081"
-      KEYLINE_HOST: "http://localhost:5173"
-    restart: unless-stopped

--- a/internal/handlers/sessions.go
+++ b/internal/handlers/sessions.go
@@ -1,0 +1,150 @@
+package handlers
+
+import (
+	"Keyline/internal/database"
+	"Keyline/internal/logging"
+	"Keyline/internal/middlewares"
+	"Keyline/internal/repositories"
+	"Keyline/utils"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/The127/ioc"
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+)
+
+type activeSessionDto struct {
+	VsName      string `json:"vsName"`
+	Username    string `json:"username"`
+	DisplayName string `json:"displayName"`
+}
+
+func ListActiveSessions(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	scope := middlewares.GetScope(ctx)
+
+	sessionService := ioc.GetDependency[middlewares.SessionService](scope)
+	dbContext := ioc.GetDependency[database.Context](scope)
+
+	result := make([]activeSessionDto, 0)
+
+	logging.Logger.Debugf("ListActiveSessions: %d cookies in request", len(r.Cookies()))
+
+	for _, cookie := range r.Cookies() {
+		if !strings.HasPrefix(cookie.Name, "keylineSession_") {
+			continue
+		}
+		vsName := strings.TrimPrefix(cookie.Name, "keylineSession_")
+		logging.Logger.Debugf("ListActiveSessions: found session cookie for vsName=%s", vsName)
+
+		token, err := utils.DecodeSplitToken(cookie.Value)
+		if err != nil {
+			logging.Logger.Debugf("ListActiveSessions: failed to decode split token for vsName=%s: %v", vsName, err)
+			continue
+		}
+
+		tokenId, err := uuid.Parse(token.Id())
+		if err != nil {
+			logging.Logger.Debugf("ListActiveSessions: failed to parse token id for vsName=%s: %v", vsName, err)
+			continue
+		}
+
+		session, err := sessionService.GetSession(ctx, vsName, tokenId)
+		if err != nil {
+			logging.Logger.Debugf("ListActiveSessions: GetSession error for vsName=%s: %v", vsName, err)
+			continue
+		}
+		if session == nil {
+			logging.Logger.Debugf("ListActiveSessions: session not found for vsName=%s tokenId=%s", vsName, tokenId)
+			continue
+		}
+
+		if !utils.CheapCompareHash(token.Secret(), session.HashedSecret()) {
+			logging.Logger.Debugf("ListActiveSessions: hash mismatch for vsName=%s", vsName)
+			continue
+		}
+
+		vsFilter := repositories.NewVirtualServerFilter().Name(vsName)
+		vs, err := dbContext.VirtualServers().FirstOrNil(ctx, vsFilter)
+		if err != nil {
+			logging.Logger.Debugf("ListActiveSessions: VirtualServer lookup error for vsName=%s: %v", vsName, err)
+			continue
+		}
+		if vs == nil {
+			logging.Logger.Debugf("ListActiveSessions: VirtualServer not found for vsName=%s", vsName)
+			continue
+		}
+
+		userFilter := repositories.NewUserFilter().VirtualServerId(vs.Id()).Id(session.UserId())
+		user, err := dbContext.Users().FirstOrNil(ctx, userFilter)
+		if err != nil {
+			logging.Logger.Debugf("ListActiveSessions: User lookup error for vsName=%s userId=%s: %v", vsName, session.UserId(), err)
+			continue
+		}
+		if user == nil {
+			logging.Logger.Debugf("ListActiveSessions: User not found for vsName=%s userId=%s", vsName, session.UserId())
+			continue
+		}
+
+		logging.Logger.Debugf("ListActiveSessions: resolved session for vsName=%s username=%s", vsName, user.Username())
+		result = append(result, activeSessionDto{
+			VsName:      vsName,
+			Username:    user.Username(),
+			DisplayName: user.DisplayName(),
+		})
+	}
+
+	logging.Logger.Debugf("ListActiveSessions: returning %d sessions", len(result))
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(result); err != nil {
+		logging.Logger.Warnf("ListActiveSessions: failed to encode response: %v", err)
+	}
+}
+
+func DeleteActiveSession(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	scope := middlewares.GetScope(ctx)
+
+	vsName := mux.Vars(r)["vsName"]
+	if vsName == "" {
+		http.Error(w, "missing vsName", http.StatusBadRequest)
+		return
+	}
+
+	sessionService := ioc.GetDependency[middlewares.SessionService](scope)
+
+	cookie, err := r.Cookie(middlewares.GetSessionCookieName(vsName))
+	if err != nil {
+		middlewares.ClearSessionCookie(w, vsName)
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	token, err := utils.DecodeSplitToken(cookie.Value)
+	if err != nil {
+		middlewares.ClearSessionCookie(w, vsName)
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	tokenId, err := uuid.Parse(token.Id())
+	if err != nil {
+		middlewares.ClearSessionCookie(w, vsName)
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	session, err := sessionService.GetSession(ctx, vsName, tokenId)
+	if err == nil && session != nil && utils.CheapCompareHash(token.Secret(), session.HashedSecret()) {
+		if err := sessionService.DeleteSession(ctx, vsName, tokenId); err != nil {
+			logging.Logger.Warnf("DeleteActiveSession: failed to delete session for vsName=%s: %v", vsName, err)
+		}
+	}
+
+	middlewares.ClearSessionCookie(w, vsName)
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/middlewares/SessionMiddleware.go
+++ b/internal/middlewares/SessionMiddleware.go
@@ -149,12 +149,16 @@ func CreateSession(w http.ResponseWriter, r *http.Request, vsName string, userId
 	return nil
 }
 
+func ClearSessionCookie(w http.ResponseWriter, vsName string) {
+	setCookie(w, GetSessionCookieName(vsName), "", -1)
+}
+
 func setCookie(w http.ResponseWriter, name string, value string, maxAge int) {
 	cookie := http.Cookie{
 		Name:     name,
 		Value:    value,
 		Path:     "/",
-		Domain:   config.C.Server.ExternalUrl,
+		Domain:   config.C.Server.ExternalDomain,
 		MaxAge:   maxAge,
 		Secure:   true,
 		HttpOnly: true,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -119,6 +119,24 @@ func Serve(dp *ioc.DependencyProvider, serverConfig config.ServerConfig) {
 }
 
 func mapApiRoutes(r *mux.Router) {
+	sessionsRouter := r.PathPrefix("/api/sessions").Subrouter()
+	sessionsRouter.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			origin := r.Header.Get("Origin")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, DELETE")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+			w.Header().Set("Access-Control-Allow-Credentials", "true")
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+			if r.Method == http.MethodOptions {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	})
+	sessionsRouter.HandleFunc("", handlers.ListActiveSessions).Methods(http.MethodGet, http.MethodOptions)
+	sessionsRouter.HandleFunc("/{vsName}", handlers.DeleteActiveSession).Methods(http.MethodDelete, http.MethodOptions)
+
 	apiRouter := r.PathPrefix("/api").Subrouter()
 
 	apiRouter.Use(gh.CORS(


### PR DESCRIPTION
## Summary
- Adds `GET /api/sessions` — enumerates session cookies on the request and returns tenant/user info for each valid session.
- Adds `DELETE /api/sessions/{vsName}` — terminates the session for a specific tenant (clears the DB row and the cookie).
- Fixes session cookie `Domain` to use `Server.ExternalDomain` (hostname) instead of `Server.ExternalUrl` (full URL).
- Drops the bundled `keyline-ui` service from `docker-compose.yml`.

## Test plan
- [ ] `GET /api/sessions` with no cookies returns `[]`.
- [ ] `GET /api/sessions` after logging into one or more tenants returns each one.
- [ ] `DELETE /api/sessions/{vsName}` clears the cookie and the DB session; the entry disappears from the next `GET`.