### PR TITLE
feat: device flow on GET application + fix login/registration PATCH

### DIFF
--- a/internal/handlers/applications.go
+++ b/internal/handlers/applications.go
@@ -119,6 +119,8 @@ type GetApplicationResponseDto struct {
 
 	ClaimsMappingScript *string `json:"customClaimsMappingScript"`
 
+	DeviceFlowEnabled bool `json:"deviceFlowEnabled"`
+
 	CreatedAt time.Time `json:"createdAt"`
 	UpdatedAt time.Time `json:"updatedAt"`
 }
@@ -186,6 +188,7 @@ func GetApplication(w http.ResponseWriter, r *http.Request) {
 		PostLogoutRedirectUris: application.PostLogoutUris,
 		SystemApplication:      application.SystemApplication,
 		ClaimsMappingScript:    application.ClaimsMappingScript,
+		DeviceFlowEnabled:      application.DeviceFlowEnabled,
 		CreatedAt:              application.CreatedAt,
 		UpdatedAt:              application.UpdatedAt,
 	})

--- a/internal/handlers/virtualServers.go
+++ b/internal/handlers/virtualServers.go
@@ -316,8 +316,11 @@ func PatchVirtualServer(w http.ResponseWriter, r *http.Request) {
 
 	m := ioc.GetDependency[mediatr.Mediator](scope)
 	command := commands.PatchVirtualServer{
-		VirtualServerName: vsName,
-		DisplayName:       utils.TrimSpace(dto.DisplayName),
+		VirtualServerName:        vsName,
+		DisplayName:              utils.TrimSpace(dto.DisplayName),
+		EnableRegistration:       dto.EnableRegistration,
+		Require2fa:               dto.Require2fa,
+		RequireEmailVerification: dto.RequireEmailVerification,
 	}
 	_, err = mediatr.Send[*commands.PatchVirtualServerResponse](ctx, m, command)
 	if err != nil {

--- a/internal/queries/GetApplicationQuery.go
+++ b/internal/queries/GetApplicationQuery.go
@@ -46,6 +46,7 @@ type GetApplicationResult struct {
 	PostLogoutUris      []string
 	SystemApplication   bool
 	ClaimsMappingScript *string
+	DeviceFlowEnabled   bool
 	CreatedAt           time.Time
 	UpdatedAt           time.Time
 }
@@ -91,6 +92,7 @@ func HandleGetApplication(ctx context.Context, query GetApplication) (*GetApplic
 		PostLogoutUris:      application.PostLogoutRedirectUris(),
 		SystemApplication:   application.SystemApplication(),
 		ClaimsMappingScript: application.ClaimsMappingScript(),
+		DeviceFlowEnabled:   application.DeviceFlowEnabled(),
 		CreatedAt:           application.AuditCreatedAt(),
 		UpdatedAt:           application.AuditUpdatedAt(),
 	}, nil


### PR DESCRIPTION
## Summary

Two related backend changes needed by pending KeylineUi v0.2.7 work:

- **feat:** expose `deviceFlowEnabled` on the GET application response. The flag was already settable via create/patch but was missing from the GET DTO, so the admin UI couldn't show its current state.
- **fix:** the `PatchVirtualServer` handler accepted `enableRegistration`, `require2fa`, and `requireEmailVerification` in the DTO but only forwarded `displayName` to the command — the matching command fields and setters already existed. Those three toggles were silent no-ops.

## Test plan

- [ ] `go build ./...` passes
- [ ] Existing CI (6 required checks)
- [ ] Manual: GET application returns `deviceFlowEnabled`
- [ ] Manual: PATCH virtual server with any of the three bools persists the change