### PR TITLE
feat: extract public api/ package and add project client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,6 +150,7 @@ Temporary Items
 .todo
 Keyline
 api
+!api/
 queue-worker
 keys
 /bin

--- a/api/applications.go
+++ b/api/applications.go
@@ -1,0 +1,57 @@
+package api
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type CreateApplicationRequestDto struct {
+	Name                  string   `json:"name" validate:"required,min=1,max=255"`
+	DisplayName           string   `json:"displayName" validate:"required,min=1,max=255"`
+	RedirectUris          []string `json:"redirectUris" validate:"required,dive,url,min=1"`
+	PostLogoutUris        []string `json:"postLogoutUris" validate:"dive,url"`
+	Type                  string   `json:"type" validate:"required,oneof=public confidential"`
+	AccessTokenHeaderType *string  `json:"accessTokenHeaderType" validate:"omitempty,oneof=at+jwt JWT"`
+	DeviceFlowEnabled     bool     `json:"deviceFlowEnabled"`
+}
+
+type CreateApplicationResponseDto struct {
+	Id     uuid.UUID `json:"id"`
+	Secret *string   `json:"secret,omitempty"`
+}
+
+type GetApplicationResponseDto struct {
+	Id          uuid.UUID `json:"id"`
+	Name        string    `json:"name"`
+	DisplayName string    `json:"displayName"`
+	Type        string    `json:"type"`
+
+	RedirectUris           []string `json:"redirectUris"`
+	PostLogoutRedirectUris []string `json:"postLogoutRedirectUris"`
+
+	SystemApplication bool `json:"systemApplication"`
+
+	ClaimsMappingScript *string `json:"customClaimsMappingScript"`
+
+	DeviceFlowEnabled bool `json:"deviceFlowEnabled"`
+
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+type PatchApplicationRequestDto struct {
+	DisplayName         *string `json:"displayName"`
+	ClaimsMappingScript *string `json:"customClaimsMappingScript"`
+	DeviceFlowEnabled   *bool   `json:"deviceFlowEnabled"`
+}
+
+type PagedApplicationsResponseDto = PagedResponseDto[ListApplicationsResponseDto]
+
+type ListApplicationsResponseDto struct {
+	Id                uuid.UUID `json:"id"`
+	Name              string    `json:"name"`
+	DisplayName       string    `json:"displayName"`
+	Type              string    `json:"type"`
+	SystemApplication bool      `json:"systemApplication"`
+}

--- a/api/audit.go
+++ b/api/audit.go
@@ -1,0 +1,27 @@
+package api
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type PagedAuditLogResponseDto struct {
+	Items      []ListAuditLogResponseDto `json:"items"`
+	Pagination Pagination                `json:"pagination"`
+}
+
+type ListAuditLogResponseDto struct {
+	Id     uuid.UUID  `json:"id"`
+	UserId *uuid.UUID `json:"userId"`
+
+	RequestType  string          `json:"requestType"`
+	RequestData  map[string]any  `json:"requestData"`
+	ResponseData *map[string]any `json:"responseData"`
+
+	Allowed         bool            `json:"allowed"`
+	AllowReasonType *string         `json:"allowReasonType"`
+	AllowReason     *map[string]any `json:"allowReason"`
+
+	CreatedAt time.Time `json:"createdAt"`
+}

--- a/api/groups.go
+++ b/api/groups.go
@@ -1,0 +1,10 @@
+package api
+
+import "github.com/google/uuid"
+
+type PagedGroupsResponseDto = PagedResponseDto[ListGroupsResponseDto]
+
+type ListGroupsResponseDto struct {
+	Id   uuid.UUID `json:"id"`
+	Name string    `json:"name"`
+}

--- a/api/oidc.go
+++ b/api/oidc.go
@@ -1,0 +1,19 @@
+package api
+
+type DeviceAuthorizationResponse struct {
+	DeviceCode              string `json:"device_code"`
+	UserCode                string `json:"user_code"`
+	VerificationUri         string `json:"verification_uri"`
+	VerificationUriComplete string `json:"verification_uri_complete"`
+	ExpiresIn               int    `json:"expires_in"`
+	Interval                int    `json:"interval"`
+}
+
+type DeviceTokenResponse struct {
+	TokenType    string `json:"token_type"`
+	IdToken      string `json:"id_token"`
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	Scope        string `json:"scope"`
+	ExpiresIn    int    `json:"expires_in"`
+}

--- a/api/paged.go
+++ b/api/paged.go
@@ -1,0 +1,13 @@
+package api
+
+type PagedResponseDto[T any] struct {
+	Items      []T         `json:"items"`
+	Pagination *Pagination `json:"pagination"`
+}
+
+type Pagination struct {
+	Size       int `json:"size"`
+	Page       int `json:"page"`
+	TotalPages int `json:"totalPages"`
+	TotalItems int `json:"totalItems"`
+}

--- a/api/passwordrules.go
+++ b/api/passwordrules.go
@@ -1,0 +1,20 @@
+package api
+
+import "github.com/google/uuid"
+
+type PagedPasswordRuleResponseDto struct {
+	Items []ListPasswordRulesResponseDto `json:"items"`
+}
+
+type ListPasswordRulesResponseDto struct {
+	Id      uuid.UUID      `json:"id"`
+	Type    string         `json:"type"`
+	Details map[string]any `json:"details"`
+}
+
+type CreatePasswordRuleRequestDto struct {
+	Type    string                 `json:"type" validate:"required"`
+	Details map[string]interface{} `json:"details" validate:"required"`
+}
+
+type PatchPasswordRuleRequestDto map[string]any

--- a/api/projects.go
+++ b/api/projects.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type CreateProjectRequestDto struct {
+	Slug        string `json:"slug" validate:"required,min=1,max=255"`
+	Name        string `json:"name" validate:"required,min=1,max=255"`
+	Description string `json:"description"`
+}
+
+type CreateProjectResponseDto struct {
+	Id uuid.UUID `json:"id"`
+}
+
+type PagedProjectsResponseDto = PagedResponseDto[ListProjectsResponseDto]
+
+type ListProjectsResponseDto struct {
+	Id            uuid.UUID `json:"id"`
+	Slug          string    `json:"slug"`
+	Name          string    `json:"name"`
+	SystemProject bool      `json:"systemProject"`
+}
+
+type GetProjectResponseDto struct {
+	Id            uuid.UUID `json:"id"`
+	Slug          string    `json:"slug"`
+	Name          string    `json:"name"`
+	Description   string    `json:"description"`
+	SystemProject bool      `json:"systemProject"`
+
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}

--- a/api/resourceservers.go
+++ b/api/resourceservers.go
@@ -1,0 +1,30 @@
+package api
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type CreateResourceServerRequestDto struct {
+	Slug        string `json:"slug" validate:"required,min=1,max=255"`
+	Name        string `json:"name" validate:"required"`
+	Description string `json:"description"`
+}
+
+type PagedResourceServersResponseDto = PagedResponseDto[ListResourceServersResponseDto]
+
+type ListResourceServersResponseDto struct {
+	Id   uuid.UUID `json:"id"`
+	Slug string    `json:"slug"`
+	Name string    `json:"name"`
+}
+
+type GetResourceServerResponseDto struct {
+	Id          uuid.UUID `json:"id"`
+	Slug        string    `json:"slug"`
+	Name        string    `json:"name"`
+	Description string    `json:"description"`
+	CreatedAt   time.Time `json:"createdAt"`
+	UpdatedAt   time.Time `json:"updatedAt"`
+}

--- a/api/resourceserverscopes.go
+++ b/api/resourceserverscopes.go
@@ -1,0 +1,34 @@
+package api
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type CreateResourceServerScopeRequestDto struct {
+	Scope       string `json:"scope" validate:"required,min=1,max=255"`
+	Name        string `json:"name" validate:"required,min=1,max=255"`
+	Description string `json:"description"`
+}
+
+type CreateResourceServerScopeResponseDto struct {
+	Id uuid.UUID `json:"id"`
+}
+
+type PagedResourceServerScopeResponseDto = PagedResponseDto[ListResourceServerScopesResponseDto]
+
+type ListResourceServerScopesResponseDto struct {
+	Id    uuid.UUID `json:"id"`
+	Scope string    `json:"scope"`
+	Name  string    `json:"name"`
+}
+
+type GetResourceServerScopeResponseDto struct {
+	Id          uuid.UUID `json:"id"`
+	Scope       string    `json:"scope"`
+	Name        string    `json:"name"`
+	Description string    `json:"description"`
+	CreatedAt   time.Time `json:"createdAt"`
+	UpdatedAt   time.Time `json:"updatedAt"`
+}

--- a/api/roles.go
+++ b/api/roles.go
@@ -1,0 +1,46 @@
+package api
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type GetRoleByIdResponseDto struct {
+	Id          uuid.UUID `json:"id"`
+	Name        string    `json:"name"`
+	Description string    `json:"description"`
+	CreatedAt   time.Time `json:"createdAt"`
+	UpdatedAt   time.Time `json:"updatedAt"`
+}
+
+type PagedRolesResponseDto struct {
+	Items      []ListRolesResponseDto `json:"items"`
+	Pagination Pagination             `json:"pagination"`
+}
+
+type ListRolesResponseDto struct {
+	Id   uuid.UUID `json:"id"`
+	Name string    `json:"name"`
+}
+
+type CreateRoleRequestDto struct {
+	Name        string `json:"name" validate:"required,min=1,max=255"`
+	Description string `json:"description" validate:"max=1024"`
+}
+
+type CreateRoleResponseDto struct {
+	Id uuid.UUID `json:"id"`
+}
+
+type AssignRoleRequestDto struct {
+	UserId uuid.UUID `json:"userId" validate:"required,uuid=4"`
+}
+
+type PagedUsersInRoleResponseDto = PagedResponseDto[ListUsersInRoleResponseDto]
+
+type ListUsersInRoleResponseDto struct {
+	Id          uuid.UUID `json:"id"`
+	Username    string    `json:"username"`
+	DisplayName string    `json:"displayName"`
+}

--- a/api/templates.go
+++ b/api/templates.go
@@ -1,0 +1,26 @@
+package api
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// PagedTemplatesResponseDto is the paged envelope for ListTemplates.
+type PagedTemplatesResponseDto struct {
+	Items      []ListTemplatesResponseDto `json:"items"`
+	Pagination Pagination                 `json:"pagination"`
+}
+
+type GetTemplateResponseDto struct {
+	Id        uuid.UUID `json:"id"`
+	Type      string    `json:"type"`
+	Text      string    `json:"text"`
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+type ListTemplatesResponseDto struct {
+	Id   uuid.UUID `json:"id"`
+	Type string    `json:"type"`
+}

--- a/api/users.go
+++ b/api/users.go
@@ -1,0 +1,127 @@
+package api
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type RegisterUserRequestDto struct {
+	Username    string `json:"username" validate:"required,min=1,max=255"`
+	DisplayName string `json:"displayName" validate:"required,min=1,max=255"`
+	Password    string `json:"password" validate:"required"`
+	Email       string `json:"email" validate:"required"`
+}
+
+type CreateUserRequestDto struct {
+	Username      string                       `json:"username" validate:"required"`
+	DisplayName   string                       `json:"displayName" validate:"required"`
+	Email         string                       `json:"email" validate:"required"`
+	EmailVerified bool                         `json:"emailVerified" validate:"required"`
+	Password      *CreateUserRequestDtoPasword `json:"password"`
+}
+
+type CreateUserRequestDtoPasword struct {
+	Plain     string `json:"plain" validate:"required"`
+	Temporary bool   `json:"temporary"`
+}
+
+type CreateUserResponseDto struct {
+	Id uuid.UUID `json:"id"`
+}
+
+type ListUsersResponseDto struct {
+	Id            uuid.UUID `json:"id"`
+	Username      string    `json:"username"`
+	DisplayName   string    `json:"displayName"`
+	PrimaryEmail  string    `json:"primaryEmail"`
+	IsServiceUser bool      `json:"isServiceUser"`
+}
+
+type PagedUsersResponseDto struct {
+	Items      []ListUsersResponseDto `json:"items"`
+	Pagination Pagination             `json:"pagination"`
+}
+
+type GetUserByIdResponseDto struct {
+	Id            uuid.UUID `json:"id"`
+	Username      string    `json:"username"`
+	DisplayName   string    `json:"displayName"`
+	PrimaryEmail  string    `json:"primaryEmail"`
+	EmailVerified bool      `json:"emailVerified"`
+	IsServiceUser bool      `json:"isServiceUser"`
+	CreatedAt     time.Time `json:"createdAt"`
+	UpdatedAt     time.Time `json:"updatedAt"`
+}
+
+type GetUserApplicationMetadataResponseDto map[string]any
+
+type GetUserGlobalMetadataResponseDto map[string]any
+
+type GetUserMetadataResponseDto struct {
+	Metadata            map[string]any `json:"metadata,omitempty"`
+	ApplicationMetadata map[string]any `json:"applicationMetadata,omitempty"`
+}
+
+type UpdateUserGlobalMetadataRequestDto map[string]any
+
+type PatchUserGlobalMetadataRequestDto map[string]any
+
+type UpdateUserApplicationMetadataRequestDto map[string]any
+
+type PatchUserApplicationMetadataRequestDto map[string]any
+
+type PatchUserRequestDto struct {
+	DisplayName   *string `json:"displayName"`
+	EmailVerified *bool   `json:"emailVerified"`
+}
+
+type CreateServiceUserRequestDto struct {
+	Username string `json:"username" validate:"required,min=1,max=255"`
+}
+
+type CreateServiceUserResponseDto struct {
+	Id uuid.UUID `json:"id"`
+}
+
+type AssociateServiceUserPublicKeyRequestDto struct {
+	PublicKey string `json:"publicKey" validate:"required"`
+}
+
+type AssociateServiceUserPublicKeyResponseDto struct {
+	Kid string `json:"kid"`
+}
+
+type PasskeyCreateChallengeResponseDto struct {
+	Id          uuid.UUID `json:"id"`
+	Challenge   string    `json:"challenge" validate:"required"`
+	UserId      uuid.UUID `json:"userId"`
+	Username    string    `json:"username"`
+	DisplayName string    `json:"displayName"`
+}
+
+type PasskeyValidateChallengeRequestDto struct {
+	Id               uuid.UUID `json:"id" validate:"required"`
+	WebauthnResponse struct {
+		Id       string `json:"id"`
+		RawId    string `json:"rawId"`
+		Response struct {
+			ClientDataJSON     string   `json:"clientDataJSON"`
+			AuthenticatorData  string   `json:"authenticatorData"`
+			Transports         []string `json:"transports"`
+			PublicKey          string   `json:"publicKey"`
+			PublicKeyAlgorithm int      `json:"publicKeyAlgorithm"`
+			AttestationObject  string   `json:"attestationObject"`
+		} `json:"response"`
+		AuthenticatorAttachment string `json:"authenticatorAttachment"`
+		Type                    string `json:"type"`
+	} `json:"webauthnResponse" validate:"required"`
+}
+
+type ListPasskeyResponseDto struct {
+	Id uuid.UUID `json:"id"`
+}
+
+type PagedListPasskeyResponseDto struct {
+	Items []ListPasskeyResponseDto `json:"items"`
+}

--- a/api/virtualservers.go
+++ b/api/virtualservers.go
@@ -1,0 +1,92 @@
+package api
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type CreateVirtualServerRequestDtoAdminDto struct {
+	Username     string   `json:"username" validate:"required,min=1,max=255"`
+	DisplayName  string   `json:"displayName" validate:"required,min=1,max=255"`
+	PrimaryEmail string   `json:"primaryEmail" validate:"required,email"`
+	PasswordHash string   `json:"passwordHash" validate:"required"`
+	Roles        []string `json:"roles"`
+}
+
+type CreateVirtualServerRequestDtoServiceUserDto struct {
+	Username  string   `json:"username" validate:"required,min=1,max=255"`
+	Roles     []string `json:"roles"`
+	PublicKey struct {
+		Pem string `json:"pem" validate:"required"`
+		Kid string `json:"kid" validate:"required"`
+	} `json:"publicKey" validate:"required"`
+}
+
+type CreateVirtualServerRequestDtoProjectDtoRoleDto struct {
+	Name        string `json:"name" validate:"required,min=1,max=255"`
+	Description string `json:"description"`
+}
+
+type CreateVirtualServerRequestDtoProjectDtoApplicationDto struct {
+	Name           string   `json:"name" validate:"required,min=1,max=255"`
+	DisplayName    string   `json:"displayName" validate:"required,min=1,max=255"`
+	Type           string   `json:"type" validate:"required,oneof=public confidential"`
+	HashedSecret   *string  `json:"hashedSecret"`
+	RedirectUris   []string `json:"redirectUris" validate:"required,dive,url,min=1"`
+	PostLogoutUris []string `json:"postLogoutUris" validate:"dive,url"`
+}
+
+type CreateVirtualServerRequestDtoProjectDtoResourceServerDto struct {
+	Slug        string `json:"slug" validate:"required,min=1,max=255"`
+	Name        string `json:"name" validate:"required,min=1,max=255"`
+	Description string `json:"description"`
+}
+
+type CreateVirtualServerRequestDtoProjectDto struct {
+	Slug        string `json:"slug" validate:"required,min=1,max=255"`
+	Name        string `json:"name" validate:"required,min=1,max=255"`
+	Description string `json:"description"`
+
+	Roles           []CreateVirtualServerRequestDtoProjectDtoRoleDto           `json:"roles"`
+	Applications    []CreateVirtualServerRequestDtoProjectDtoApplicationDto    `json:"applications"`
+	ResourceServers []CreateVirtualServerRequestDtoProjectDtoResourceServerDto `json:"resourceServers"`
+}
+
+type CreateVirtualServerRequestDto struct {
+	Name               string  `json:"name" validate:"required,min=1,max=255,alphanum"`
+	DisplayName        string  `json:"displayName" validate:"required,min=1,max=255"`
+	EnableRegistration bool    `json:"enableRegistration"`
+	SigningAlgorithm   *string `json:"signingAlgorithm" validate:"oneof=RS256 EdDSA"`
+	Require2fa         bool    `json:"require2fa"`
+
+	Admin        *CreateVirtualServerRequestDtoAdminDto        `json:"admin"`
+	ServiceUsers []CreateVirtualServerRequestDtoServiceUserDto `json:"serviceUsers"`
+	Projects     []CreateVirtualServerRequestDtoProjectDto     `json:"projects"`
+}
+
+type GetVirtualServerResponseDto struct {
+	Id                       uuid.UUID `json:"id"`
+	Name                     string    `json:"name"`
+	DisplayName              string    `json:"displayName"`
+	RegistrationEnabled      bool      `json:"registrationEnabled"`
+	Require2fa               bool      `json:"require2fa"`
+	RequireEmailVerification bool      `json:"requireEmailVerification"`
+	SigningAlgorithm         string    `json:"signingAlgorithm"`
+	CreatedAt                time.Time `json:"createdAt"`
+	UpdatedAt                time.Time `json:"updatedAt"`
+}
+
+type GetVirtualServerListResponseDto struct {
+	Name                string `json:"name"`
+	DisplayName         string `json:"displayName"`
+	RegistrationEnabled bool   `json:"registrationEnabled"`
+}
+
+type PatchVirtualServerRequestDto struct {
+	DisplayName *string `json:"displayName"`
+
+	EnableRegistration       *bool `json:"enableRegistration"`
+	Require2fa               *bool `json:"require2fa"`
+	RequireEmailVerification *bool `json:"requireEmailVerification"`
+}

--- a/client/application.go
+++ b/client/application.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	"github.com/The127/Keyline/internal/handlers"
+	"github.com/The127/Keyline/api"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -18,10 +18,10 @@ type ListApplicationParams struct {
 }
 
 type ApplicationClient interface {
-	Create(ctx context.Context, dto handlers.CreateApplicationRequestDto) (handlers.CreateApplicationResponseDto, error)
-	List(ctx context.Context, params ListApplicationParams) (handlers.PagedApplicationsResponseDto, error)
-	Get(ctx context.Context, id uuid.UUID) (handlers.GetApplicationResponseDto, error)
-	Patch(ctx context.Context, id uuid.UUID, dto handlers.PatchApplicationRequestDto) error
+	Create(ctx context.Context, dto api.CreateApplicationRequestDto) (api.CreateApplicationResponseDto, error)
+	List(ctx context.Context, params ListApplicationParams) (api.PagedApplicationsResponseDto, error)
+	Get(ctx context.Context, id uuid.UUID) (api.GetApplicationResponseDto, error)
+	Patch(ctx context.Context, id uuid.UUID, dto api.PatchApplicationRequestDto) error
 	Delete(ctx context.Context, id uuid.UUID) error
 }
 
@@ -35,34 +35,34 @@ type application struct {
 	transport *Transport
 }
 
-func (a *application) Create(ctx context.Context, dto handlers.CreateApplicationRequestDto) (handlers.CreateApplicationResponseDto, error) {
+func (a *application) Create(ctx context.Context, dto api.CreateApplicationRequestDto) (api.CreateApplicationResponseDto, error) {
 	endpoint := "/applications"
 
 	jsonBytes, err := json.Marshal(dto)
 	if err != nil {
-		return handlers.CreateApplicationResponseDto{}, fmt.Errorf("marshaling dto: %w", err)
+		return api.CreateApplicationResponseDto{}, fmt.Errorf("marshaling dto: %w", err)
 	}
 
 	request, err := a.transport.NewTenantRequest(ctx, http.MethodPost, endpoint, bytes.NewBuffer(jsonBytes))
 	if err != nil {
-		return handlers.CreateApplicationResponseDto{}, fmt.Errorf("creating request: %w", err)
+		return api.CreateApplicationResponseDto{}, fmt.Errorf("creating request: %w", err)
 	}
 
 	response, err := a.transport.Do(request)
 	if err != nil {
-		return handlers.CreateApplicationResponseDto{}, fmt.Errorf("doing request: %w", err)
+		return api.CreateApplicationResponseDto{}, fmt.Errorf("doing request: %w", err)
 	}
 
-	var responseDto handlers.CreateApplicationResponseDto
+	var responseDto api.CreateApplicationResponseDto
 	err = json.NewDecoder(response.Body).Decode(&responseDto)
 	if err != nil {
-		return handlers.CreateApplicationResponseDto{}, fmt.Errorf("decoding response: %w", err)
+		return api.CreateApplicationResponseDto{}, fmt.Errorf("decoding response: %w", err)
 	}
 
 	return responseDto, nil
 }
 
-func (a *application) List(ctx context.Context, params ListApplicationParams) (handlers.PagedApplicationsResponseDto, error) {
+func (a *application) List(ctx context.Context, params ListApplicationParams) (api.PagedApplicationsResponseDto, error) {
 	values := url.Values{}
 	values.Add("page", fmt.Sprintf("%d", params.Page))
 	values.Add("size", fmt.Sprintf("%d", params.Size))
@@ -71,40 +71,40 @@ func (a *application) List(ctx context.Context, params ListApplicationParams) (h
 
 	request, err := a.transport.NewTenantRequest(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
-		return handlers.PagedApplicationsResponseDto{}, fmt.Errorf("creating request: %w", err)
+		return api.PagedApplicationsResponseDto{}, fmt.Errorf("creating request: %w", err)
 	}
 
 	response, err := a.transport.Do(request)
 	if err != nil {
-		return handlers.PagedApplicationsResponseDto{}, fmt.Errorf("doing request: %w", err)
+		return api.PagedApplicationsResponseDto{}, fmt.Errorf("doing request: %w", err)
 	}
 
-	var responseDto handlers.PagedApplicationsResponseDto
+	var responseDto api.PagedApplicationsResponseDto
 	err = json.NewDecoder(response.Body).Decode(&responseDto)
 	if err != nil {
-		return handlers.PagedApplicationsResponseDto{}, fmt.Errorf("decoding response: %w", err)
+		return api.PagedApplicationsResponseDto{}, fmt.Errorf("decoding response: %w", err)
 	}
 
 	return responseDto, nil
 }
 
-func (a *application) Get(ctx context.Context, id uuid.UUID) (handlers.GetApplicationResponseDto, error) {
+func (a *application) Get(ctx context.Context, id uuid.UUID) (api.GetApplicationResponseDto, error) {
 	endpoint := fmt.Sprintf("/applications/%s", id.String())
 
 	request, err := a.transport.NewTenantRequest(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
-		return handlers.GetApplicationResponseDto{}, fmt.Errorf("creating request: %w", err)
+		return api.GetApplicationResponseDto{}, fmt.Errorf("creating request: %w", err)
 	}
 
 	response, err := a.transport.Do(request)
 	if err != nil {
-		return handlers.GetApplicationResponseDto{}, fmt.Errorf("doing request: %w", err)
+		return api.GetApplicationResponseDto{}, fmt.Errorf("doing request: %w", err)
 	}
 
-	var responseDto handlers.GetApplicationResponseDto
+	var responseDto api.GetApplicationResponseDto
 	err = json.NewDecoder(response.Body).Decode(&responseDto)
 	if err != nil {
-		return handlers.GetApplicationResponseDto{}, fmt.Errorf("decoding response: %w", err)
+		return api.GetApplicationResponseDto{}, fmt.Errorf("decoding response: %w", err)
 	}
 
 	return responseDto, nil
@@ -126,7 +126,7 @@ func (a *application) Delete(ctx context.Context, id uuid.UUID) error {
 	return nil
 }
 
-func (a *application) Patch(ctx context.Context, id uuid.UUID, dto handlers.PatchApplicationRequestDto) error {
+func (a *application) Patch(ctx context.Context, id uuid.UUID, dto api.PatchApplicationRequestDto) error {
 	endpoint := fmt.Sprintf("/applications/%s", id.String())
 
 	jsonBytes, err := json.Marshal(dto)

--- a/client/application.go
+++ b/client/application.go
@@ -52,6 +52,7 @@ func (a *application) Create(ctx context.Context, dto api.CreateApplicationReque
 	if err != nil {
 		return api.CreateApplicationResponseDto{}, fmt.Errorf("doing request: %w", err)
 	}
+	defer response.Body.Close() //nolint:errcheck
 
 	var responseDto api.CreateApplicationResponseDto
 	err = json.NewDecoder(response.Body).Decode(&responseDto)
@@ -78,6 +79,7 @@ func (a *application) List(ctx context.Context, params ListApplicationParams) (a
 	if err != nil {
 		return api.PagedApplicationsResponseDto{}, fmt.Errorf("doing request: %w", err)
 	}
+	defer response.Body.Close() //nolint:errcheck
 
 	var responseDto api.PagedApplicationsResponseDto
 	err = json.NewDecoder(response.Body).Decode(&responseDto)
@@ -100,6 +102,7 @@ func (a *application) Get(ctx context.Context, id uuid.UUID) (api.GetApplication
 	if err != nil {
 		return api.GetApplicationResponseDto{}, fmt.Errorf("doing request: %w", err)
 	}
+	defer response.Body.Close() //nolint:errcheck
 
 	var responseDto api.GetApplicationResponseDto
 	err = json.NewDecoder(response.Body).Decode(&responseDto)
@@ -118,10 +121,11 @@ func (a *application) Delete(ctx context.Context, id uuid.UUID) error {
 		return fmt.Errorf("creating request: %w", err)
 	}
 
-	_, err = a.transport.Do(request)
+	response, err := a.transport.Do(request)
 	if err != nil {
 		return fmt.Errorf("doing request: %w", err)
 	}
+	defer response.Body.Close() //nolint:errcheck
 
 	return nil
 }
@@ -139,10 +143,11 @@ func (a *application) Patch(ctx context.Context, id uuid.UUID, dto api.PatchAppl
 		return fmt.Errorf("creating request: %w", err)
 	}
 
-	_, err = a.transport.Do(request)
+	response, err := a.transport.Do(request)
 	if err != nil {
 		return fmt.Errorf("doing request: %w", err)
 	}
+	defer response.Body.Close() //nolint:errcheck
 
 	return nil
 }

--- a/client/application_test.go
+++ b/client/application_test.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	"github.com/The127/Keyline/internal/handlers"
+	"github.com/The127/Keyline/api"
 	"github.com/The127/Keyline/utils"
 	"encoding/json"
 	"fmt"
@@ -24,7 +24,7 @@ func TestApplicationClientSuite(t *testing.T) {
 
 func (s *ApplicationClientSuite) TestCreateApplication_HappyPath() {
 	// arrange
-	request := handlers.CreateApplicationRequestDto{
+	request := api.CreateApplicationRequestDto{
 		Name:           "applicationName",
 		DisplayName:    "displayName",
 		RedirectUris:   []string{"http://localhost:8080/callback"},
@@ -32,7 +32,7 @@ func (s *ApplicationClientSuite) TestCreateApplication_HappyPath() {
 		Type:           "confidential",
 	}
 
-	response := handlers.CreateApplicationResponseDto{
+	response := api.CreateApplicationResponseDto{
 		Id:     uuid.New(),
 		Secret: utils.Ptr("secret"),
 	}
@@ -41,7 +41,7 @@ func (s *ApplicationClientSuite) TestCreateApplication_HappyPath() {
 		s.Equal(http.MethodPost, r.Method)
 		s.Equal("/api/virtual-servers/test/applications", r.URL.Path)
 
-		var requestDto handlers.CreateApplicationRequestDto
+		var requestDto api.CreateApplicationRequestDto
 		err := json.NewDecoder(r.Body).Decode(&requestDto)
 		s.NoError(err)
 		s.Equal(request, requestDto)
@@ -68,8 +68,8 @@ func (s *ApplicationClientSuite) TestListApplications_HappyPath() {
 		Size: 11,
 	}
 
-	response := handlers.PagedApplicationsResponseDto{
-		Items: []handlers.ListApplicationsResponseDto{
+	response := api.PagedApplicationsResponseDto{
+		Items: []api.ListApplicationsResponseDto{
 			{
 				Id:                uuid.New(),
 				Name:              "name",
@@ -78,7 +78,7 @@ func (s *ApplicationClientSuite) TestListApplications_HappyPath() {
 				SystemApplication: false,
 			},
 		},
-		Pagination: &handlers.Pagination{
+		Pagination: &api.Pagination{
 			Page:       1,
 			Size:       11,
 			TotalPages: 2,
@@ -109,7 +109,7 @@ func (s *ApplicationClientSuite) TestGetApplication_HappyPath() {
 	// arrange
 	requestId := uuid.New()
 
-	response := handlers.GetApplicationResponseDto{
+	response := api.GetApplicationResponseDto{
 		Id:                uuid.UUID{},
 		Name:              "name",
 		DisplayName:       "displayName",
@@ -158,7 +158,7 @@ func (s *ApplicationClientSuite) TestDeleteApplication_HappyPath() {
 func (s *ApplicationClientSuite) TestPatchApplication_HappyPath() {
 	// arrange
 	requestId := uuid.New()
-	request := handlers.PatchApplicationRequestDto{
+	request := api.PatchApplicationRequestDto{
 		DisplayName:         utils.Ptr("New display name"),
 		ClaimsMappingScript: nil,
 	}
@@ -167,7 +167,7 @@ func (s *ApplicationClientSuite) TestPatchApplication_HappyPath() {
 		s.Equal(http.MethodPatch, r.Method)
 		s.Equal(fmt.Sprintf("/api/virtual-servers/test/applications/%s", requestId), r.URL.Path)
 
-		var requestDto handlers.PatchApplicationRequestDto
+		var requestDto api.PatchApplicationRequestDto
 		err := json.NewDecoder(r.Body).Decode(&requestDto)
 		s.NoError(err)
 		s.Equal(request, requestDto)

--- a/client/client.go
+++ b/client/client.go
@@ -5,6 +5,7 @@ type Client interface {
 	VirtualServer() VirtualServerClient
 	User() UserClient
 	Oidc() OidcClient
+	Project() ProjectClient
 }
 
 type client struct {
@@ -31,4 +32,8 @@ func (c *client) User() UserClient {
 
 func (c *client) Oidc() OidcClient {
 	return NewOidcClient(c.transport)
+}
+
+func (c *client) Project() ProjectClient {
+	return NewProjectClient(c.transport)
 }

--- a/client/oidc.go
+++ b/client/oidc.go
@@ -20,13 +20,9 @@ var (
 	ErrInvalidUserCode      = errors.New("invalid_user_code")
 )
 
-// DeviceAuthorizationResponse and DeviceTokenResponse are re-exported from api package.
-type DeviceAuthorizationResponse = api.DeviceAuthorizationResponse
-type DeviceTokenResponse = api.DeviceTokenResponse
-
 type OidcClient interface {
-	BeginDeviceFlow(ctx context.Context, clientId string, scope string) (DeviceAuthorizationResponse, error)
-	PollDeviceToken(ctx context.Context, clientId string, deviceCode string) (DeviceTokenResponse, error)
+	BeginDeviceFlow(ctx context.Context, clientId string, scope string) (api.DeviceAuthorizationResponse, error)
+	PollDeviceToken(ctx context.Context, clientId string, deviceCode string) (api.DeviceTokenResponse, error)
 	PostActivate(ctx context.Context, userCode string) (loginToken string, err error)
 	VerifyPassword(ctx context.Context, loginToken string, username string, password string) error
 	FinishLogin(ctx context.Context, loginToken string) error
@@ -40,7 +36,7 @@ func NewOidcClient(transport *Transport) OidcClient {
 	return &oidcClient{transport: transport}
 }
 
-func (o *oidcClient) BeginDeviceFlow(ctx context.Context, clientId string, scope string) (DeviceAuthorizationResponse, error) {
+func (o *oidcClient) BeginDeviceFlow(ctx context.Context, clientId string, scope string) (api.DeviceAuthorizationResponse, error) {
 	formValues := url.Values{
 		"client_id": {clientId},
 		"scope":     {scope},
@@ -48,25 +44,25 @@ func (o *oidcClient) BeginDeviceFlow(ctx context.Context, clientId string, scope
 
 	req, err := o.transport.NewOidcRequest(ctx, http.MethodPost, "/device", strings.NewReader(formValues.Encode()))
 	if err != nil {
-		return DeviceAuthorizationResponse{}, fmt.Errorf("creating request: %w", err)
+		return api.DeviceAuthorizationResponse{}, fmt.Errorf("creating request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	resp, err := o.transport.Do(req)
 	if err != nil {
-		return DeviceAuthorizationResponse{}, fmt.Errorf("doing request: %w", err)
+		return api.DeviceAuthorizationResponse{}, fmt.Errorf("doing request: %w", err)
 	}
 	defer resp.Body.Close() //nolint:errcheck
 
-	var result DeviceAuthorizationResponse
+	var result api.DeviceAuthorizationResponse
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return DeviceAuthorizationResponse{}, fmt.Errorf("decoding response: %w", err)
+		return api.DeviceAuthorizationResponse{}, fmt.Errorf("decoding response: %w", err)
 	}
 
 	return result, nil
 }
 
-func (o *oidcClient) PollDeviceToken(ctx context.Context, clientId string, deviceCode string) (DeviceTokenResponse, error) {
+func (o *oidcClient) PollDeviceToken(ctx context.Context, clientId string, deviceCode string) (api.DeviceTokenResponse, error) {
 	formValues := url.Values{
 		"grant_type":  {"urn:ietf:params:oauth:grant-type:device_code"},
 		"client_id":   {clientId},
@@ -75,13 +71,13 @@ func (o *oidcClient) PollDeviceToken(ctx context.Context, clientId string, devic
 
 	req, err := o.transport.NewOidcRequest(ctx, http.MethodPost, "/token", strings.NewReader(formValues.Encode()))
 	if err != nil {
-		return DeviceTokenResponse{}, fmt.Errorf("creating request: %w", err)
+		return api.DeviceTokenResponse{}, fmt.Errorf("creating request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	resp, err := o.transport.DoRaw(req)
 	if err != nil {
-		return DeviceTokenResponse{}, fmt.Errorf("doing request: %w", err)
+		return api.DeviceTokenResponse{}, fmt.Errorf("doing request: %w", err)
 	}
 	defer resp.Body.Close() //nolint:errcheck
 
@@ -93,25 +89,25 @@ func (o *oidcClient) PollDeviceToken(ctx context.Context, clientId string, devic
 		_ = json.NewDecoder(resp.Body).Decode(&oauthErr)
 		switch oauthErr.Error {
 		case "authorization_pending":
-			return DeviceTokenResponse{}, ErrAuthorizationPending
+			return api.DeviceTokenResponse{}, ErrAuthorizationPending
 		case "access_denied":
-			return DeviceTokenResponse{}, ErrAccessDenied
+			return api.DeviceTokenResponse{}, ErrAccessDenied
 		case "expired_token":
-			return DeviceTokenResponse{}, ErrExpiredToken
+			return api.DeviceTokenResponse{}, ErrExpiredToken
 		case "slow_down":
-			return DeviceTokenResponse{}, ErrSlowDown
+			return api.DeviceTokenResponse{}, ErrSlowDown
 		default:
-			return DeviceTokenResponse{}, fmt.Errorf("oauth error %s: %s", oauthErr.Error, oauthErr.ErrorDescription)
+			return api.DeviceTokenResponse{}, fmt.Errorf("oauth error %s: %s", oauthErr.Error, oauthErr.ErrorDescription)
 		}
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return DeviceTokenResponse{}, ApiError{Message: resp.Status, Code: resp.StatusCode}
+		return api.DeviceTokenResponse{}, ApiError{Message: resp.Status, Code: resp.StatusCode}
 	}
 
-	var result DeviceTokenResponse
+	var result api.DeviceTokenResponse
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return DeviceTokenResponse{}, fmt.Errorf("decoding response: %w", err)
+		return api.DeviceTokenResponse{}, fmt.Errorf("decoding response: %w", err)
 	}
 
 	return result, nil

--- a/client/oidc.go
+++ b/client/oidc.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"github.com/The127/Keyline/api"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -19,23 +20,9 @@ var (
 	ErrInvalidUserCode      = errors.New("invalid_user_code")
 )
 
-type DeviceAuthorizationResponse struct {
-	DeviceCode              string `json:"device_code"`
-	UserCode                string `json:"user_code"`
-	VerificationUri         string `json:"verification_uri"`
-	VerificationUriComplete string `json:"verification_uri_complete"`
-	ExpiresIn               int    `json:"expires_in"`
-	Interval                int    `json:"interval"`
-}
-
-type DeviceTokenResponse struct {
-	TokenType    string `json:"token_type"`
-	IdToken      string `json:"id_token"`
-	AccessToken  string `json:"access_token"`
-	RefreshToken string `json:"refresh_token"`
-	Scope        string `json:"scope"`
-	ExpiresIn    int    `json:"expires_in"`
-}
+// DeviceAuthorizationResponse and DeviceTokenResponse are re-exported from api package.
+type DeviceAuthorizationResponse = api.DeviceAuthorizationResponse
+type DeviceTokenResponse = api.DeviceTokenResponse
 
 type OidcClient interface {
 	BeginDeviceFlow(ctx context.Context, clientId string, scope string) (DeviceAuthorizationResponse, error)

--- a/client/oidc_test.go
+++ b/client/oidc_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/The127/Keyline/api"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -19,7 +20,7 @@ func TestOidcClientSuite(t *testing.T) {
 }
 
 func (s *OidcClientSuite) TestBeginDeviceFlow_HappyPath() {
-	expected := DeviceAuthorizationResponse{
+	expected := api.DeviceAuthorizationResponse{
 		DeviceCode:              "device-code-abc",
 		UserCode:                "ABCD-EFGH",
 		VerificationUri:         "http://localhost/oidc/test/activate",
@@ -69,7 +70,7 @@ func (s *OidcClientSuite) TestBeginDeviceFlow_RejectsUnknownApp() {
 }
 
 func (s *OidcClientSuite) TestPollDeviceToken_HappyPath() {
-	expected := DeviceTokenResponse{
+	expected := api.DeviceTokenResponse{
 		TokenType:    "Bearer",
 		IdToken:      "id-token-value",
 		AccessToken:  "access-token-value",

--- a/client/project.go
+++ b/client/project.go
@@ -1,0 +1,71 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/The127/Keyline/api"
+)
+
+type ProjectClient interface {
+	Create(ctx context.Context, input api.CreateProjectRequestDto) (api.CreateProjectResponseDto, error)
+	Get(ctx context.Context, slug string) (api.GetProjectResponseDto, error)
+}
+
+func NewProjectClient(transport *Transport) ProjectClient {
+	return &projectClient{transport: transport}
+}
+
+type projectClient struct {
+	transport *Transport
+}
+
+func (c *projectClient) Create(ctx context.Context, input api.CreateProjectRequestDto) (api.CreateProjectResponseDto, error) {
+	jsonBytes, err := json.Marshal(input)
+	if err != nil {
+		return api.CreateProjectResponseDto{}, fmt.Errorf("marshaling input: %w", err)
+	}
+
+	request, err := c.transport.NewTenantRequest(ctx, http.MethodPost, "/projects", bytes.NewBuffer(jsonBytes))
+	if err != nil {
+		return api.CreateProjectResponseDto{}, fmt.Errorf("creating request: %w", err)
+	}
+
+	response, err := c.transport.Do(request)
+	if err != nil {
+		return api.CreateProjectResponseDto{}, fmt.Errorf("doing request: %w", err)
+	}
+	defer response.Body.Close() //nolint:errcheck
+
+	var responseDto api.CreateProjectResponseDto
+	if err := json.NewDecoder(response.Body).Decode(&responseDto); err != nil {
+		return api.CreateProjectResponseDto{}, fmt.Errorf("decoding response: %w", err)
+	}
+
+	return responseDto, nil
+}
+
+func (c *projectClient) Get(ctx context.Context, slug string) (api.GetProjectResponseDto, error) {
+	endpoint := fmt.Sprintf("/projects/%s", slug)
+
+	request, err := c.transport.NewTenantRequest(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return api.GetProjectResponseDto{}, fmt.Errorf("creating request: %w", err)
+	}
+
+	response, err := c.transport.Do(request)
+	if err != nil {
+		return api.GetProjectResponseDto{}, fmt.Errorf("doing request: %w", err)
+	}
+	defer response.Body.Close() //nolint:errcheck
+
+	var responseDto api.GetProjectResponseDto
+	if err := json.NewDecoder(response.Body).Decode(&responseDto); err != nil {
+		return api.GetProjectResponseDto{}, fmt.Errorf("decoding response: %w", err)
+	}
+
+	return responseDto, nil
+}

--- a/client/user.go
+++ b/client/user.go
@@ -51,6 +51,7 @@ func (c *userClient) List(ctx context.Context, params ListUserParams) (api.Paged
 	if err != nil {
 		return api.PagedUsersResponseDto{}, fmt.Errorf("doing request: %w", err)
 	}
+	defer response.Body.Close() //nolint:errcheck
 
 	var responseDto api.PagedUsersResponseDto
 	err = json.NewDecoder(response.Body).Decode(&responseDto)
@@ -73,6 +74,7 @@ func (c *userClient) Get(ctx context.Context, id uuid.UUID) (api.GetUserByIdResp
 	if err != nil {
 		return api.GetUserByIdResponseDto{}, fmt.Errorf("doing request: %w", err)
 	}
+	defer response.Body.Close() //nolint:errcheck
 
 	var responseDto api.GetUserByIdResponseDto
 	err = json.NewDecoder(response.Body).Decode(&responseDto)
@@ -96,10 +98,11 @@ func (c *userClient) Patch(ctx context.Context, id uuid.UUID, dto api.PatchUserR
 		return fmt.Errorf("creating request: %w", err)
 	}
 
-	_, err = c.transport.Do(request)
+	response, err := c.transport.Do(request)
 	if err != nil {
 		return fmt.Errorf("doing request: %w", err)
 	}
+	defer response.Body.Close() //nolint:errcheck
 
 	return nil
 }
@@ -119,6 +122,7 @@ func (c *userClient) CreateServiceUser(ctx context.Context, username string) (uu
 	if err != nil {
 		return uuid.UUID{}, fmt.Errorf("doing request: %w", err)
 	}
+	defer response.Body.Close() //nolint:errcheck
 
 	var responseDto api.CreateServiceUserResponseDto
 	if err := json.NewDecoder(response.Body).Decode(&responseDto); err != nil {
@@ -144,6 +148,7 @@ func (c *userClient) AssociateServiceUserPublicKey(ctx context.Context, serviceU
 	if err != nil {
 		return "", fmt.Errorf("doing request: %w", err)
 	}
+	defer response.Body.Close() //nolint:errcheck
 
 	var responseDto api.AssociateServiceUserPublicKeyResponseDto
 	if err := json.NewDecoder(response.Body).Decode(&responseDto); err != nil {

--- a/client/user.go
+++ b/client/user.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	"github.com/The127/Keyline/internal/handlers"
+	"github.com/The127/Keyline/api"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -18,9 +18,9 @@ type ListUserParams struct {
 }
 
 type UserClient interface {
-	List(ctx context.Context, params ListUserParams) (handlers.PagedUsersResponseDto, error)
-	Get(ctx context.Context, id uuid.UUID) (handlers.GetUserByIdResponseDto, error)
-	Patch(ctx context.Context, id uuid.UUID, dto handlers.PatchUserRequestDto) error
+	List(ctx context.Context, params ListUserParams) (api.PagedUsersResponseDto, error)
+	Get(ctx context.Context, id uuid.UUID) (api.GetUserByIdResponseDto, error)
+	Patch(ctx context.Context, id uuid.UUID, dto api.PatchUserRequestDto) error
 	CreateServiceUser(ctx context.Context, username string) (uuid.UUID, error)
 	AssociateServiceUserPublicKey(ctx context.Context, serviceUserID uuid.UUID, publicKeyPEM string) (string, error)
 }
@@ -35,7 +35,7 @@ type userClient struct {
 	transport *Transport
 }
 
-func (c *userClient) List(ctx context.Context, params ListUserParams) (handlers.PagedUsersResponseDto, error) {
+func (c *userClient) List(ctx context.Context, params ListUserParams) (api.PagedUsersResponseDto, error) {
 	values := url.Values{}
 	values.Add("page", fmt.Sprintf("%d", params.Page))
 	values.Add("size", fmt.Sprintf("%d", params.Size))
@@ -44,46 +44,46 @@ func (c *userClient) List(ctx context.Context, params ListUserParams) (handlers.
 
 	request, err := c.transport.NewTenantRequest(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
-		return handlers.PagedUsersResponseDto{}, fmt.Errorf("creating request: %w", err)
+		return api.PagedUsersResponseDto{}, fmt.Errorf("creating request: %w", err)
 	}
 
 	response, err := c.transport.Do(request)
 	if err != nil {
-		return handlers.PagedUsersResponseDto{}, fmt.Errorf("doing request: %w", err)
+		return api.PagedUsersResponseDto{}, fmt.Errorf("doing request: %w", err)
 	}
 
-	var responseDto handlers.PagedUsersResponseDto
+	var responseDto api.PagedUsersResponseDto
 	err = json.NewDecoder(response.Body).Decode(&responseDto)
 	if err != nil {
-		return handlers.PagedUsersResponseDto{}, fmt.Errorf("decoding response: %w", err)
+		return api.PagedUsersResponseDto{}, fmt.Errorf("decoding response: %w", err)
 	}
 
 	return responseDto, nil
 }
 
-func (c *userClient) Get(ctx context.Context, id uuid.UUID) (handlers.GetUserByIdResponseDto, error) {
+func (c *userClient) Get(ctx context.Context, id uuid.UUID) (api.GetUserByIdResponseDto, error) {
 	endpoint := fmt.Sprintf("/users/%s", id.String())
 
 	request, err := c.transport.NewTenantRequest(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
-		return handlers.GetUserByIdResponseDto{}, fmt.Errorf("creating request: %w", err)
+		return api.GetUserByIdResponseDto{}, fmt.Errorf("creating request: %w", err)
 	}
 
 	response, err := c.transport.Do(request)
 	if err != nil {
-		return handlers.GetUserByIdResponseDto{}, fmt.Errorf("doing request: %w", err)
+		return api.GetUserByIdResponseDto{}, fmt.Errorf("doing request: %w", err)
 	}
 
-	var responseDto handlers.GetUserByIdResponseDto
+	var responseDto api.GetUserByIdResponseDto
 	err = json.NewDecoder(response.Body).Decode(&responseDto)
 	if err != nil {
-		return handlers.GetUserByIdResponseDto{}, fmt.Errorf("decoding response: %w", err)
+		return api.GetUserByIdResponseDto{}, fmt.Errorf("decoding response: %w", err)
 	}
 
 	return responseDto, nil
 }
 
-func (c *userClient) Patch(ctx context.Context, id uuid.UUID, dto handlers.PatchUserRequestDto) error {
+func (c *userClient) Patch(ctx context.Context, id uuid.UUID, dto api.PatchUserRequestDto) error {
 	endpoint := fmt.Sprintf("/users/%s", id.String())
 
 	jsonBytes, err := json.Marshal(dto)
@@ -105,7 +105,7 @@ func (c *userClient) Patch(ctx context.Context, id uuid.UUID, dto handlers.Patch
 }
 
 func (c *userClient) CreateServiceUser(ctx context.Context, username string) (uuid.UUID, error) {
-	jsonBytes, err := json.Marshal(handlers.CreateServiceUserRequestDto{Username: username})
+	jsonBytes, err := json.Marshal(api.CreateServiceUserRequestDto{Username: username})
 	if err != nil {
 		return uuid.UUID{}, fmt.Errorf("marshaling dto: %w", err)
 	}
@@ -120,7 +120,7 @@ func (c *userClient) CreateServiceUser(ctx context.Context, username string) (uu
 		return uuid.UUID{}, fmt.Errorf("doing request: %w", err)
 	}
 
-	var responseDto handlers.CreateServiceUserResponseDto
+	var responseDto api.CreateServiceUserResponseDto
 	if err := json.NewDecoder(response.Body).Decode(&responseDto); err != nil {
 		return uuid.UUID{}, fmt.Errorf("decoding response: %w", err)
 	}
@@ -129,7 +129,7 @@ func (c *userClient) CreateServiceUser(ctx context.Context, username string) (uu
 }
 
 func (c *userClient) AssociateServiceUserPublicKey(ctx context.Context, serviceUserID uuid.UUID, publicKeyPEM string) (string, error) {
-	jsonBytes, err := json.Marshal(handlers.AssociateServiceUserPublicKeyRequestDto{PublicKey: publicKeyPEM})
+	jsonBytes, err := json.Marshal(api.AssociateServiceUserPublicKeyRequestDto{PublicKey: publicKeyPEM})
 	if err != nil {
 		return "", fmt.Errorf("marshaling dto: %w", err)
 	}
@@ -145,7 +145,7 @@ func (c *userClient) AssociateServiceUserPublicKey(ctx context.Context, serviceU
 		return "", fmt.Errorf("doing request: %w", err)
 	}
 
-	var responseDto handlers.AssociateServiceUserPublicKeyResponseDto
+	var responseDto api.AssociateServiceUserPublicKeyResponseDto
 	if err := json.NewDecoder(response.Body).Decode(&responseDto); err != nil {
 		return "", fmt.Errorf("decoding response: %w", err)
 	}

--- a/client/user_test.go
+++ b/client/user_test.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	"github.com/The127/Keyline/internal/handlers"
+	"github.com/The127/Keyline/api"
 	"github.com/The127/Keyline/utils"
 	"encoding/json"
 	"fmt"
@@ -29,8 +29,8 @@ func (s *UserClientSuite) TestListUsers_HappyPath() {
 		Size: 11,
 	}
 
-	response := handlers.PagedUsersResponseDto{
-		Items: []handlers.ListUsersResponseDto{
+	response := api.PagedUsersResponseDto{
+		Items: []api.ListUsersResponseDto{
 			{
 				Id:            uuid.New(),
 				Username:      "username",
@@ -39,7 +39,7 @@ func (s *UserClientSuite) TestListUsers_HappyPath() {
 				IsServiceUser: false,
 			},
 		},
-		Pagination: handlers.Pagination{
+		Pagination: api.Pagination{
 			Page:       1,
 			Size:       11,
 			TotalPages: 2,
@@ -70,7 +70,7 @@ func (s *UserClientSuite) TestGetUser_HappyPath() {
 	// arrange
 	requestId := uuid.New()
 
-	response := handlers.GetUserByIdResponseDto{
+	response := api.GetUserByIdResponseDto{
 		Id:            requestId,
 		Username:      "username",
 		DisplayName:   "displayName",
@@ -100,7 +100,7 @@ func (s *UserClientSuite) TestGetUser_HappyPath() {
 func (s *UserClientSuite) TestPatchUser_HappyPath() {
 	// arrange
 	requestId := uuid.New()
-	request := handlers.PatchUserRequestDto{
+	request := api.PatchUserRequestDto{
 		DisplayName: utils.Ptr("New display name"),
 	}
 
@@ -108,7 +108,7 @@ func (s *UserClientSuite) TestPatchUser_HappyPath() {
 		s.Equal(http.MethodPatch, r.Method)
 		s.Equal(fmt.Sprintf("/api/virtual-servers/test/users/%s", requestId), r.URL.Path)
 
-		var requestDto handlers.PatchUserRequestDto
+		var requestDto api.PatchUserRequestDto
 		err := json.NewDecoder(r.Body).Decode(&requestDto)
 		s.NoError(err)
 		s.Equal(request, requestDto)

--- a/client/virtualserver.go
+++ b/client/virtualserver.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	"github.com/The127/Keyline/internal/handlers"
+	"github.com/The127/Keyline/api"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -9,11 +9,27 @@ import (
 	"net/http"
 )
 
+// VirtualServerState holds the fields of a virtual server relevant to reconciliation.
+type VirtualServerState struct {
+	DisplayName              string `json:"displayName"`
+	RegistrationEnabled      bool   `json:"registrationEnabled"`
+	Require2fa               bool   `json:"require2fa"`
+	RequireEmailVerification bool   `json:"requireEmailVerification"`
+}
+
+// PatchVirtualServerInput holds the fields that can be patched on a virtual server.
+type PatchVirtualServerInput struct {
+	DisplayName              *string `json:"displayName"`
+	EnableRegistration       *bool   `json:"enableRegistration"`
+	Require2fa               *bool   `json:"require2fa"`
+	RequireEmailVerification *bool   `json:"requireEmailVerification"`
+}
+
 type VirtualServerClient interface {
-	Create(ctx context.Context, dto handlers.CreateVirtualServerRequestDto) error
-	Get(ctx context.Context) (handlers.GetVirtualServerResponseDto, error)
-	GetPublicInfo(ctx context.Context) (handlers.GetVirtualServerListResponseDto, error)
-	Patch(ctx context.Context, dto handlers.PatchVirtualServerRequestDto) error
+	Create(ctx context.Context, dto api.CreateVirtualServerRequestDto) error
+	Get(ctx context.Context) (VirtualServerState, error)
+	GetPublicInfo(ctx context.Context) (api.GetVirtualServerListResponseDto, error)
+	Patch(ctx context.Context, input PatchVirtualServerInput) error
 }
 
 func NewVirtualServerClient(transport *Transport) VirtualServerClient {
@@ -26,7 +42,7 @@ type virtualServerClient struct {
 	transport *Transport
 }
 
-func (c *virtualServerClient) Create(ctx context.Context, dto handlers.CreateVirtualServerRequestDto) error {
+func (c *virtualServerClient) Create(ctx context.Context, dto api.CreateVirtualServerRequestDto) error {
 	jsonBytes, err := json.Marshal(dto)
 	if err != nil {
 		return fmt.Errorf("marshaling dto: %w", err)
@@ -45,51 +61,50 @@ func (c *virtualServerClient) Create(ctx context.Context, dto handlers.CreateVir
 	return nil
 }
 
-func (c *virtualServerClient) Get(ctx context.Context) (handlers.GetVirtualServerResponseDto, error) {
+func (c *virtualServerClient) Get(ctx context.Context) (VirtualServerState, error) {
 	endpoint := ""
 
 	request, err := c.transport.NewTenantRequest(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
-		return handlers.GetVirtualServerResponseDto{}, fmt.Errorf("creating request: %w", err)
+		return VirtualServerState{}, fmt.Errorf("creating request: %w", err)
 	}
 
 	response, err := c.transport.Do(request)
 	if err != nil {
-		return handlers.GetVirtualServerResponseDto{}, fmt.Errorf("doing request: %w", err)
+		return VirtualServerState{}, fmt.Errorf("doing request: %w", err)
 	}
 
-	var responseDto handlers.GetVirtualServerResponseDto
-	err = json.NewDecoder(response.Body).Decode(&responseDto)
-	if err != nil {
-		return handlers.GetVirtualServerResponseDto{}, fmt.Errorf("decoding response: %w", err)
+	var state VirtualServerState
+	if err := json.NewDecoder(response.Body).Decode(&state); err != nil {
+		return VirtualServerState{}, fmt.Errorf("decoding response: %w", err)
 	}
 
-	return responseDto, nil
+	return state, nil
 }
 
-func (c *virtualServerClient) GetPublicInfo(ctx context.Context) (handlers.GetVirtualServerListResponseDto, error) {
+func (c *virtualServerClient) GetPublicInfo(ctx context.Context) (api.GetVirtualServerListResponseDto, error) {
 	endpoint := "/public-info"
 
 	request, err := c.transport.NewTenantRequest(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
-		return handlers.GetVirtualServerListResponseDto{}, fmt.Errorf("creating request: %w", err)
+		return api.GetVirtualServerListResponseDto{}, fmt.Errorf("creating request: %w", err)
 	}
 
 	response, err := c.transport.Do(request)
 	if err != nil {
-		return handlers.GetVirtualServerListResponseDto{}, fmt.Errorf("doing request: %w", err)
+		return api.GetVirtualServerListResponseDto{}, fmt.Errorf("doing request: %w", err)
 	}
 
-	var responseDto handlers.GetVirtualServerListResponseDto
+	var responseDto api.GetVirtualServerListResponseDto
 	err = json.NewDecoder(response.Body).Decode(&responseDto)
 	if err != nil {
-		return handlers.GetVirtualServerListResponseDto{}, fmt.Errorf("decoding response: %w", err)
+		return api.GetVirtualServerListResponseDto{}, fmt.Errorf("decoding response: %w", err)
 	}
 
 	return responseDto, nil
 }
 
-func (c *virtualServerClient) Patch(ctx context.Context, dto handlers.PatchVirtualServerRequestDto) error {
+func (c *virtualServerClient) Patch(ctx context.Context, dto PatchVirtualServerInput) error {
 	endpoint := ""
 
 	jsonBytes, err := json.Marshal(dto)

--- a/client/virtualserver.go
+++ b/client/virtualserver.go
@@ -9,14 +9,6 @@ import (
 	"net/http"
 )
 
-// VirtualServerState holds the fields of a virtual server relevant to reconciliation.
-type VirtualServerState struct {
-	DisplayName              string `json:"displayName"`
-	RegistrationEnabled      bool   `json:"registrationEnabled"`
-	Require2fa               bool   `json:"require2fa"`
-	RequireEmailVerification bool   `json:"requireEmailVerification"`
-}
-
 // PatchVirtualServerInput holds the fields that can be patched on a virtual server.
 type PatchVirtualServerInput struct {
 	DisplayName              *string `json:"displayName"`
@@ -27,7 +19,7 @@ type PatchVirtualServerInput struct {
 
 type VirtualServerClient interface {
 	Create(ctx context.Context, dto api.CreateVirtualServerRequestDto) error
-	Get(ctx context.Context) (VirtualServerState, error)
+	Get(ctx context.Context) (api.GetVirtualServerResponseDto, error)
 	GetPublicInfo(ctx context.Context) (api.GetVirtualServerListResponseDto, error)
 	Patch(ctx context.Context, input PatchVirtualServerInput) error
 }
@@ -53,30 +45,32 @@ func (c *virtualServerClient) Create(ctx context.Context, dto api.CreateVirtualS
 		return fmt.Errorf("creating request: %w", err)
 	}
 
-	_, err = c.transport.Do(request)
+	response, err := c.transport.Do(request)
 	if err != nil {
 		return fmt.Errorf("doing request: %w", err)
 	}
+	defer response.Body.Close() //nolint:errcheck
 
 	return nil
 }
 
-func (c *virtualServerClient) Get(ctx context.Context) (VirtualServerState, error) {
+func (c *virtualServerClient) Get(ctx context.Context) (api.GetVirtualServerResponseDto, error) {
 	endpoint := ""
 
 	request, err := c.transport.NewTenantRequest(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
-		return VirtualServerState{}, fmt.Errorf("creating request: %w", err)
+		return api.GetVirtualServerResponseDto{}, fmt.Errorf("creating request: %w", err)
 	}
 
 	response, err := c.transport.Do(request)
 	if err != nil {
-		return VirtualServerState{}, fmt.Errorf("doing request: %w", err)
+		return api.GetVirtualServerResponseDto{}, fmt.Errorf("doing request: %w", err)
 	}
+	defer response.Body.Close() //nolint:errcheck
 
-	var state VirtualServerState
+	var state api.GetVirtualServerResponseDto
 	if err := json.NewDecoder(response.Body).Decode(&state); err != nil {
-		return VirtualServerState{}, fmt.Errorf("decoding response: %w", err)
+		return api.GetVirtualServerResponseDto{}, fmt.Errorf("decoding response: %w", err)
 	}
 
 	return state, nil
@@ -94,6 +88,7 @@ func (c *virtualServerClient) GetPublicInfo(ctx context.Context) (api.GetVirtual
 	if err != nil {
 		return api.GetVirtualServerListResponseDto{}, fmt.Errorf("doing request: %w", err)
 	}
+	defer response.Body.Close() //nolint:errcheck
 
 	var responseDto api.GetVirtualServerListResponseDto
 	err = json.NewDecoder(response.Body).Decode(&responseDto)
@@ -117,10 +112,11 @@ func (c *virtualServerClient) Patch(ctx context.Context, dto PatchVirtualServerI
 		return fmt.Errorf("creating request: %w", err)
 	}
 
-	_, err = c.transport.Do(request)
+	response, err := c.transport.Do(request)
 	if err != nil {
 		return fmt.Errorf("doing request: %w", err)
 	}
+	defer response.Body.Close() //nolint:errcheck
 
 	return nil
 }

--- a/client/virtualserver_test.go
+++ b/client/virtualserver_test.go
@@ -54,7 +54,7 @@ func (s *VirtualServerClientSuite) TestCreate_HappyPath() {
 
 func (s *VirtualServerClientSuite) TestGet_HappyPath() {
 	// arrange
-	response := VirtualServerState{
+	response := api.GetVirtualServerResponseDto{
 		DisplayName:              "Display Name",
 		Require2fa:               false,
 		RequireEmailVerification: false,

--- a/client/virtualserver_test.go
+++ b/client/virtualserver_test.go
@@ -1,14 +1,13 @@
 package client
 
 import (
-	"github.com/The127/Keyline/internal/handlers"
+	"github.com/The127/Keyline/api"
 	"github.com/The127/Keyline/utils"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -23,7 +22,7 @@ func TestVirtualServerClientSuite(t *testing.T) {
 
 func (s *VirtualServerClientSuite) TestCreate_HappyPath() {
 	// arrange
-	request := handlers.CreateVirtualServerRequestDto{
+	request := api.CreateVirtualServerRequestDto{
 		Name:               "name",
 		DisplayName:        "Display Name",
 		EnableRegistration: false,
@@ -35,7 +34,7 @@ func (s *VirtualServerClientSuite) TestCreate_HappyPath() {
 		s.Equal(http.MethodPost, r.Method)
 		s.Equal("/api/virtual-servers", r.URL.Path)
 
-		var requestDto handlers.CreateVirtualServerRequestDto
+		var requestDto api.CreateVirtualServerRequestDto
 		err := json.NewDecoder(r.Body).Decode(&requestDto)
 		s.NoError(err)
 		s.Equal(request, requestDto)
@@ -55,11 +54,8 @@ func (s *VirtualServerClientSuite) TestCreate_HappyPath() {
 
 func (s *VirtualServerClientSuite) TestGet_HappyPath() {
 	// arrange
-	response := handlers.GetVirtualServerResponseDto{
-		Id:                       uuid.New(),
-		Name:                     "name",
+	response := VirtualServerState{
 		DisplayName:              "Display Name",
-		SigningAlgorithm:         "EdDSA",
 		Require2fa:               false,
 		RequireEmailVerification: false,
 		RegistrationEnabled:      false,
@@ -86,7 +82,7 @@ func (s *VirtualServerClientSuite) TestGet_HappyPath() {
 
 func (s *VirtualServerClientSuite) TestGetPublic_InfoHappyPath() {
 	// arrange
-	response := handlers.GetVirtualServerListResponseDto{
+	response := api.GetVirtualServerListResponseDto{
 		Name:                "name",
 		DisplayName:         "Display Name",
 		RegistrationEnabled: false,
@@ -113,7 +109,7 @@ func (s *VirtualServerClientSuite) TestGetPublic_InfoHappyPath() {
 
 func (s *VirtualServerClientSuite) TestPatch_HappyPath() {
 	// arrange
-	request := handlers.PatchVirtualServerRequestDto{
+	request := PatchVirtualServerInput{
 		DisplayName:              utils.Ptr("New display name"),
 		EnableRegistration:       utils.Ptr(true),
 		Require2fa:               utils.Ptr(false),
@@ -124,7 +120,7 @@ func (s *VirtualServerClientSuite) TestPatch_HappyPath() {
 		s.Equal(http.MethodPatch, r.Method)
 		s.Equal("/api/virtual-servers/test", r.URL.Path)
 
-		var requestDto handlers.PatchVirtualServerRequestDto
+		var requestDto PatchVirtualServerInput
 		err := json.NewDecoder(r.Body).Decode(&requestDto)
 		s.NoError(err)
 		s.Equal(request, requestDto)

--- a/internal/handlers/applications.go
+++ b/internal/handlers/applications.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"github.com/The127/Keyline/api"
 	"github.com/The127/Keyline/internal/commands"
 	"github.com/The127/Keyline/internal/middlewares"
 	"github.com/The127/Keyline/internal/queries"
@@ -8,7 +9,6 @@ import (
 	"github.com/The127/Keyline/utils"
 	"encoding/json"
 	"net/http"
-	"time"
 
 	"github.com/The127/ioc"
 	"github.com/The127/mediatr"
@@ -17,20 +17,13 @@ import (
 	"github.com/gorilla/mux"
 )
 
-type CreateApplicationRequestDto struct {
-	Name                  string   `json:"name" validate:"required,min=1,max=255"`
-	DisplayName           string   `json:"displayName" validate:"required,min=1,max=255"`
-	RedirectUris          []string `json:"redirectUris" validate:"required,dive,url,min=1"`
-	PostLogoutUris        []string `json:"postLogoutUris" validate:"dive,url"`
-	Type                  string   `json:"type" validate:"required,oneof=public confidential"`
-	AccessTokenHeaderType *string  `json:"accessTokenHeaderType" validate:"omitempty,oneof=at+jwt JWT"`
-	DeviceFlowEnabled     bool     `json:"deviceFlowEnabled"`
-}
-
-type CreateApplicationResponseDto struct {
-	Id     uuid.UUID `json:"id"`
-	Secret *string   `json:"secret,omitempty"`
-}
+// Type aliases to keep handler code compiling.
+type CreateApplicationRequestDto = api.CreateApplicationRequestDto
+type CreateApplicationResponseDto = api.CreateApplicationResponseDto
+type GetApplicationResponseDto = api.GetApplicationResponseDto
+type PatchApplicationRequestDto = api.PatchApplicationRequestDto
+type PagedApplicationsResponseDto = api.PagedApplicationsResponseDto
+type ListApplicationsResponseDto = api.ListApplicationsResponseDto
 
 // CreateApplication creates a new application (OIDC client) in a project
 // @Summary Create application
@@ -106,25 +99,6 @@ func CreateApplication(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-type GetApplicationResponseDto struct {
-	Id          uuid.UUID `json:"id"`
-	Name        string    `json:"name"`
-	DisplayName string    `json:"displayName"`
-	Type        string    `json:"type"`
-
-	RedirectUris           []string `json:"redirectUris"`
-	PostLogoutRedirectUris []string `json:"postLogoutRedirectUris"`
-
-	SystemApplication bool `json:"systemApplication"`
-
-	ClaimsMappingScript *string `json:"customClaimsMappingScript"`
-
-	DeviceFlowEnabled bool `json:"deviceFlowEnabled"`
-
-	CreatedAt time.Time `json:"createdAt"`
-	UpdatedAt time.Time `json:"updatedAt"`
-}
-
 // GetApplication retrieves details of a specific application by ID
 // @Summary Get application
 // @Description Get an application by ID from a project
@@ -195,12 +169,6 @@ func GetApplication(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		utils.HandleHttpError(w, err)
 	}
-}
-
-type PatchApplicationRequestDto struct {
-	DisplayName         *string `json:"displayName"`
-	ClaimsMappingScript *string `json:"customClaimsMappingScript"`
-	DeviceFlowEnabled   *bool   `json:"deviceFlowEnabled"`
 }
 
 // PatchApplication updates fields of a specific application by ID
@@ -306,16 +274,6 @@ func DeleteApplication(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusNoContent)
-}
-
-type PagedApplicationsResponseDto = PagedResponseDto[ListApplicationsResponseDto]
-
-type ListApplicationsResponseDto struct {
-	Id                uuid.UUID `json:"id"`
-	Name              string    `json:"name"`
-	DisplayName       string    `json:"displayName"`
-	Type              string    `json:"type"`
-	SystemApplication bool      `json:"systemApplication"`
 }
 
 // ListApplications lists applications in a project

--- a/internal/handlers/applications.go
+++ b/internal/handlers/applications.go
@@ -17,14 +17,6 @@ import (
 	"github.com/gorilla/mux"
 )
 
-// Type aliases to keep handler code compiling.
-type CreateApplicationRequestDto = api.CreateApplicationRequestDto
-type CreateApplicationResponseDto = api.CreateApplicationResponseDto
-type GetApplicationResponseDto = api.GetApplicationResponseDto
-type PatchApplicationRequestDto = api.PatchApplicationRequestDto
-type PagedApplicationsResponseDto = api.PagedApplicationsResponseDto
-type ListApplicationsResponseDto = api.ListApplicationsResponseDto
-
 // CreateApplication creates a new application (OIDC client) in a project
 // @Summary Create application
 // @Description Create a new OIDC application/client with redirect URIs and type
@@ -50,7 +42,7 @@ func CreateApplication(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	projectSlug := vars["projectSlug"]
 
-	var dto CreateApplicationRequestDto
+	var dto api.CreateApplicationRequestDto
 	err = json.NewDecoder(r.Body).Decode(&dto)
 	if err != nil {
 		utils.HandleHttpError(w, err)
@@ -90,7 +82,7 @@ func CreateApplication(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 
-	err = json.NewEncoder(w).Encode(CreateApplicationResponseDto{
+	err = json.NewEncoder(w).Encode(api.CreateApplicationResponseDto{
 		Id:     response.Id,
 		Secret: response.Secret,
 	})
@@ -153,7 +145,7 @@ func GetApplication(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 
-	err = json.NewEncoder(w).Encode(GetApplicationResponseDto{
+	err = json.NewEncoder(w).Encode(api.GetApplicationResponseDto{
 		Id:                     application.Id,
 		Name:                   application.Name,
 		DisplayName:            application.DisplayName,
@@ -204,7 +196,7 @@ func PatchApplication(w http.ResponseWriter, r *http.Request) {
 		utils.HandleHttpError(w, utils.ErrInvalidUuid)
 	}
 
-	var dto PatchApplicationRequestDto
+	var dto api.PatchApplicationRequestDto
 	err = json.NewDecoder(r.Body).Decode(&dto)
 	if err != nil {
 		utils.HandleHttpError(w, err)
@@ -326,8 +318,8 @@ func ListApplications(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	items := utils.MapSlice(applications.Items, func(x queries.ListApplicationsResponseItem) ListApplicationsResponseDto {
-		return ListApplicationsResponseDto{
+	items := utils.MapSlice(applications.Items, func(x queries.ListApplicationsResponseItem) api.ListApplicationsResponseDto {
+		return api.ListApplicationsResponseDto{
 			Id:                x.Id,
 			Name:              x.Name,
 			DisplayName:       x.DisplayName,

--- a/internal/handlers/audit.go
+++ b/internal/handlers/audit.go
@@ -12,10 +12,6 @@ import (
 	"github.com/The127/mediatr"
 )
 
-// Type aliases to keep handler code compiling.
-type PagedAuditLogResponseDto = api.PagedAuditLogResponseDto
-type ListAuditLogResponseDto = api.ListAuditLogResponseDto
-
 // ListAuditLog
 // @summary     List audit log entries
 // @description Retrieve a paginated list of audit log entries within a virtual server.
@@ -57,8 +53,8 @@ func ListAuditLog(w http.ResponseWriter, r *http.Request) {
 		utils.HandleHttpError(w, err)
 	}
 
-	items := utils.MapSlice(auditEntries.Items, func(x queries.ListAuditEntriesResponseItem) ListAuditLogResponseDto {
-		return ListAuditLogResponseDto{
+	items := utils.MapSlice(auditEntries.Items, func(x queries.ListAuditEntriesResponseItem) api.ListAuditLogResponseDto {
+		return api.ListAuditLogResponseDto{
 			Id:     x.Id,
 			UserId: x.UserId,
 

--- a/internal/handlers/audit.go
+++ b/internal/handlers/audit.go
@@ -1,38 +1,20 @@
 package handlers
 
 import (
+	"github.com/The127/Keyline/api"
 	"github.com/The127/Keyline/internal/middlewares"
 	"github.com/The127/Keyline/internal/queries"
 	"github.com/The127/Keyline/utils"
 	"encoding/json"
 	"net/http"
-	"time"
 
 	"github.com/The127/ioc"
 	"github.com/The127/mediatr"
-
-	"github.com/google/uuid"
 )
 
-type PagedAuditLogResponseDto struct {
-	Items      []ListAuditLogResponseDto `json:"items"`
-	Pagination Pagination                `json:"pagination"`
-}
-
-type ListAuditLogResponseDto struct {
-	Id     uuid.UUID  `json:"id"`
-	UserId *uuid.UUID `json:"userId"`
-
-	RequestType  string          `json:"requestType"`
-	RequestData  map[string]any  `json:"requestData"`
-	ResponseData *map[string]any `json:"responseData"`
-
-	Allowed         bool            `json:"allowed"`
-	AllowReasonType *string         `json:"allowReasonType"`
-	AllowReason     *map[string]any `json:"allowReason"`
-
-	CreatedAt time.Time `json:"createdAt"`
-}
+// Type aliases to keep handler code compiling.
+type PagedAuditLogResponseDto = api.PagedAuditLogResponseDto
+type ListAuditLogResponseDto = api.ListAuditLogResponseDto
 
 // ListAuditLog
 // @summary     List audit log entries

--- a/internal/handlers/groups.go
+++ b/internal/handlers/groups.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"github.com/The127/Keyline/api"
 	"github.com/The127/Keyline/internal/middlewares"
 	"github.com/The127/Keyline/internal/queries"
 	"github.com/The127/Keyline/utils"
@@ -9,16 +10,11 @@ import (
 
 	"github.com/The127/ioc"
 	"github.com/The127/mediatr"
-
-	"github.com/google/uuid"
 )
 
-type PagedGroupsResponseDto = PagedResponseDto[ListGroupsResponseDto]
-
-type ListGroupsResponseDto struct {
-	Id   uuid.UUID `json:"id"`
-	Name string    `json:"name"`
-}
+// Type aliases to keep handler code compiling.
+type PagedGroupsResponseDto = api.PagedGroupsResponseDto
+type ListGroupsResponseDto = api.ListGroupsResponseDto
 
 // ListGroups lists groups in a virtual server
 // @Summary List groups

--- a/internal/handlers/groups.go
+++ b/internal/handlers/groups.go
@@ -12,10 +12,6 @@ import (
 	"github.com/The127/mediatr"
 )
 
-// Type aliases to keep handler code compiling.
-type PagedGroupsResponseDto = api.PagedGroupsResponseDto
-type ListGroupsResponseDto = api.ListGroupsResponseDto
-
 // ListGroups lists groups in a virtual server
 // @Summary List groups
 // @Description Retrieve a paginated list of groups
@@ -60,8 +56,8 @@ func ListGroups(w http.ResponseWriter, r *http.Request) {
 		utils.HandleHttpError(w, err)
 	}
 
-	items := utils.MapSlice(groups.Items, func(x queries.ListGroupsResponseItem) ListGroupsResponseDto {
-		return ListGroupsResponseDto{
+	items := utils.MapSlice(groups.Items, func(x queries.ListGroupsResponseItem) api.ListGroupsResponseDto {
+		return api.ListGroupsResponseDto{
 			Id:   x.Id,
 			Name: x.Name,
 		}

--- a/internal/handlers/oidc.go
+++ b/internal/handlers/oidc.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"github.com/The127/Keyline/api"
 	"github.com/The127/Keyline/internal/config"
 	"github.com/The127/Keyline/internal/database"
 	"github.com/The127/Keyline/internal/jsonTypes"
@@ -30,6 +31,9 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 )
+
+// Type aliases for OIDC DTOs moved to api package.
+type DeviceAuthorizationResponse = api.DeviceAuthorizationResponse
 
 type OidcError struct {
 	Error            string
@@ -1686,15 +1690,6 @@ func handleTokenExchange(w http.ResponseWriter, r *http.Request) {
 		utils.HandleHttpError(w, fmt.Errorf("encoding response: %w", err))
 		return
 	}
-}
-
-type DeviceAuthorizationResponse struct {
-	DeviceCode              string `json:"device_code"`
-	UserCode                string `json:"user_code"`
-	VerificationUri         string `json:"verification_uri"`
-	VerificationUriComplete string `json:"verification_uri_complete"`
-	ExpiresIn               int    `json:"expires_in"`
-	Interval                int    `json:"interval"`
 }
 
 func generateUserCode() string {

--- a/internal/handlers/oidc.go
+++ b/internal/handlers/oidc.go
@@ -32,9 +32,6 @@ import (
 	"github.com/google/uuid"
 )
 
-// Type aliases for OIDC DTOs moved to api package.
-type DeviceAuthorizationResponse = api.DeviceAuthorizationResponse
-
 type OidcError struct {
 	Error            string
 	ErrorDescription string
@@ -1804,7 +1801,7 @@ func BeginDeviceFlow(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 
-	response := DeviceAuthorizationResponse{
+	response := api.DeviceAuthorizationResponse{
 		DeviceCode:              deviceCode,
 		UserCode:                userCode,
 		VerificationUri:         verificationUri,

--- a/internal/handlers/pagedresponsedto.go
+++ b/internal/handlers/pagedresponsedto.go
@@ -2,10 +2,6 @@ package handlers
 
 import "github.com/The127/Keyline/api"
 
-// Type aliases so existing handler code compiles without changes.
-type PagedResponseDto[T any] = api.PagedResponseDto[T]
-type Pagination = api.Pagination
-
 func NewPagedResponseDto[T any](items []T, queryOps *QueryOps, totalItems int) api.PagedResponseDto[T] {
 	var pagination *api.Pagination
 	if queryOps.PageSize > 0 {

--- a/internal/handlers/pagedresponsedto.go
+++ b/internal/handlers/pagedresponsedto.go
@@ -1,21 +1,15 @@
 package handlers
 
-type PagedResponseDto[T any] struct {
-	Items      []T         `json:"items"`
-	Pagination *Pagination `json:"pagination"`
-}
+import "github.com/The127/Keyline/api"
 
-type Pagination struct {
-	Size       int `json:"size"`
-	Page       int `json:"page"`
-	TotalPages int `json:"totalPages"`
-	TotalItems int `json:"totalItems"`
-}
+// Type aliases so existing handler code compiles without changes.
+type PagedResponseDto[T any] = api.PagedResponseDto[T]
+type Pagination = api.Pagination
 
-func NewPagedResponseDto[T any](items []T, queryOps *QueryOps, totalItems int) PagedResponseDto[T] {
-	var pagination *Pagination
+func NewPagedResponseDto[T any](items []T, queryOps *QueryOps, totalItems int) api.PagedResponseDto[T] {
+	var pagination *api.Pagination
 	if queryOps.PageSize > 0 {
-		pagination = &Pagination{
+		pagination = &api.Pagination{
 			Size:       queryOps.PageSize,
 			Page:       queryOps.Page,
 			TotalPages: totalItems/queryOps.PageSize + 1,
@@ -23,7 +17,7 @@ func NewPagedResponseDto[T any](items []T, queryOps *QueryOps, totalItems int) P
 		}
 	}
 
-	return PagedResponseDto[T]{
+	return api.PagedResponseDto[T]{
 		Items:      items,
 		Pagination: pagination,
 	}

--- a/internal/handlers/passwordrules.go
+++ b/internal/handlers/passwordrules.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"github.com/The127/Keyline/api"
 	"github.com/The127/Keyline/internal/commands"
 	"github.com/The127/Keyline/internal/middlewares"
 	"github.com/The127/Keyline/internal/queries"
@@ -13,19 +14,14 @@ import (
 	"github.com/The127/ioc"
 	"github.com/The127/mediatr"
 
-	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 )
 
-type PagedPasswordRuleResponseDto struct {
-	Items []ListPasswordRulesResponseDto `json:"items"`
-}
-
-type ListPasswordRulesResponseDto struct {
-	Id      uuid.UUID      `json:"id"`
-	Type    string         `json:"type"`
-	Details map[string]any `json:"details"`
-}
+// Type aliases to keep handler code compiling.
+type PagedPasswordRuleResponseDto = api.PagedPasswordRuleResponseDto
+type ListPasswordRulesResponseDto = api.ListPasswordRulesResponseDto
+type CreatePasswordRuleRequestDto = api.CreatePasswordRuleRequestDto
+type PatchPasswordRuleRequestDto = api.PatchPasswordRuleRequestDto
 
 // ListPasswordRules
 // @summary     List password rules
@@ -84,11 +80,6 @@ func ListPasswordRules(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-type CreatePasswordRuleRequestDto struct {
-	Type    string                 `json:"type" validate:"required"`
-	Details map[string]interface{} `json:"details" validate:"required"`
-}
-
 // CreatePasswordRule
 // @summary     Create password rule
 // @description Create a password rule for a virtual server.
@@ -136,8 +127,6 @@ func CreatePasswordRule(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusNoContent)
 }
-
-type PatchPasswordRuleRequestDto map[string]any
 
 // UpdatePasswordRule
 // @summary     Update a password rule

--- a/internal/handlers/passwordrules.go
+++ b/internal/handlers/passwordrules.go
@@ -17,12 +17,6 @@ import (
 	"github.com/gorilla/mux"
 )
 
-// Type aliases to keep handler code compiling.
-type PagedPasswordRuleResponseDto = api.PagedPasswordRuleResponseDto
-type ListPasswordRulesResponseDto = api.ListPasswordRulesResponseDto
-type CreatePasswordRuleRequestDto = api.CreatePasswordRuleRequestDto
-type PatchPasswordRuleRequestDto = api.PatchPasswordRuleRequestDto
-
 // ListPasswordRules
 // @summary     List password rules
 // @description Retrieve all password rules of a virtual server.
@@ -54,7 +48,7 @@ func ListPasswordRules(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	response := PagedPasswordRuleResponseDto{}
+	response := api.PagedPasswordRuleResponseDto{}
 
 	for _, rule := range rules.Items {
 		details := make(map[string]any)
@@ -64,7 +58,7 @@ func ListPasswordRules(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		response.Items = append(response.Items, ListPasswordRulesResponseDto{
+		response.Items = append(response.Items, api.ListPasswordRulesResponseDto{
 			Id:      rule.Id,
 			Type:    string(rule.Type),
 			Details: details,
@@ -100,7 +94,7 @@ func CreatePasswordRule(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var requestDto CreatePasswordRuleRequestDto
+	var requestDto api.CreatePasswordRuleRequestDto
 	err = json.NewDecoder(r.Body).Decode(&requestDto)
 	if err != nil {
 		utils.HandleHttpError(w, err)
@@ -157,7 +151,7 @@ func UpdatePasswordRule(w http.ResponseWriter, r *http.Request) {
 
 	ruleType := repositories.PasswordRuleType(ruleTypeString)
 
-	var requestDto PatchPasswordRuleRequestDto
+	var requestDto api.PatchPasswordRuleRequestDto
 	err = json.NewDecoder(r.Body).Decode(&requestDto)
 	if err != nil {
 		utils.HandleHttpError(w, err)

--- a/internal/handlers/projects.go
+++ b/internal/handlers/projects.go
@@ -1,30 +1,26 @@
 package handlers
 
 import (
+	"github.com/The127/Keyline/api"
 	"github.com/The127/Keyline/internal/commands"
 	"github.com/The127/Keyline/internal/middlewares"
 	"github.com/The127/Keyline/internal/queries"
 	"github.com/The127/Keyline/utils"
 	"encoding/json"
 	"net/http"
-	"time"
 
 	"github.com/The127/ioc"
 	"github.com/The127/mediatr"
 
-	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 )
 
-type CreateProjectRequestDto struct {
-	Slug        string `json:"slug" validate:"required,min=1,max=255"`
-	Name        string `json:"name" validate:"required,min=1,max=255"`
-	Description string `json:"description"`
-}
-
-type CreateProjectResponseDto struct {
-	Id uuid.UUID `json:"id"`
-}
+// Type aliases to keep handler code compiling.
+type CreateProjectRequestDto = api.CreateProjectRequestDto
+type CreateProjectResponseDto = api.CreateProjectResponseDto
+type PagedProjectsResponseDto = api.PagedProjectsResponseDto
+type ListProjectsResponseDto = api.ListProjectsResponseDto
+type GetProjectResponseDto = api.GetProjectResponseDto
 
 // CreateProject creates a new project
 // @Summary Create project
@@ -84,15 +80,6 @@ func CreateProject(w http.ResponseWriter, r *http.Request) {
 		utils.HandleHttpError(w, err)
 		return
 	}
-}
-
-type PagedProjectsResponseDto = PagedResponseDto[ListProjectsResponseDto]
-
-type ListProjectsResponseDto struct {
-	Id            uuid.UUID `json:"id"`
-	Slug          string    `json:"slug"`
-	Name          string    `json:"name"`
-	SystemProject bool      `json:"systemProject"`
 }
 
 // ListProjects lists projects in a virtual server
@@ -160,17 +147,6 @@ func ListProjects(w http.ResponseWriter, r *http.Request) {
 		utils.HandleHttpError(w, err)
 		return
 	}
-}
-
-type GetProjectResponseDto struct {
-	Id            uuid.UUID `json:"id"`
-	Slug          string    `json:"slug"`
-	Name          string    `json:"name"`
-	Description   string    `json:"description"`
-	SystemProject bool      `json:"systemProject"`
-
-	CreatedAt time.Time `json:"createdAt"`
-	UpdatedAt time.Time `json:"updatedAt"`
 }
 
 func GetProject(w http.ResponseWriter, r *http.Request) {

--- a/internal/handlers/projects.go
+++ b/internal/handlers/projects.go
@@ -15,13 +15,6 @@ import (
 	"github.com/gorilla/mux"
 )
 
-// Type aliases to keep handler code compiling.
-type CreateProjectRequestDto = api.CreateProjectRequestDto
-type CreateProjectResponseDto = api.CreateProjectResponseDto
-type PagedProjectsResponseDto = api.PagedProjectsResponseDto
-type ListProjectsResponseDto = api.ListProjectsResponseDto
-type GetProjectResponseDto = api.GetProjectResponseDto
-
 // CreateProject creates a new project
 // @Summary Create project
 // @Description Create a new project
@@ -43,7 +36,7 @@ func CreateProject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var dto CreateProjectRequestDto
+	var dto api.CreateProjectRequestDto
 	err = json.NewDecoder(r.Body).Decode(&dto)
 	if err != nil {
 		utils.HandleHttpError(w, err)
@@ -73,7 +66,7 @@ func CreateProject(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 
-	err = json.NewEncoder(w).Encode(CreateProjectResponseDto{
+	err = json.NewEncoder(w).Encode(api.CreateProjectResponseDto{
 		Id: response.Id,
 	})
 	if err != nil {
@@ -127,8 +120,8 @@ func ListProjects(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	items := utils.MapSlice(projects.Items, func(x queries.ListProjectsResponseItem) ListProjectsResponseDto {
-		return ListProjectsResponseDto{
+	items := utils.MapSlice(projects.Items, func(x queries.ListProjectsResponseItem) api.ListProjectsResponseDto {
+		return api.ListProjectsResponseDto{
 			Id:            x.Id,
 			Slug:          x.Slug,
 			Name:          x.Name,
@@ -175,7 +168,7 @@ func GetProject(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 
-	err = json.NewEncoder(w).Encode(GetProjectResponseDto{
+	err = json.NewEncoder(w).Encode(api.GetProjectResponseDto{
 		Id:          resp.Id,
 		Slug:        resp.Slug,
 		Name:        resp.Name,

--- a/internal/handlers/resourceservers.go
+++ b/internal/handlers/resourceservers.go
@@ -16,12 +16,6 @@ import (
 	"github.com/gorilla/mux"
 )
 
-// Type aliases to keep handler code compiling.
-type CreateResourceServerRequestDto = api.CreateResourceServerRequestDto
-type PagedResourceServersResponseDto = api.PagedResourceServersResponseDto
-type ListResourceServersResponseDto = api.ListResourceServersResponseDto
-type GetResourceServerResponseDto = api.GetResourceServerResponseDto
-
 // CreateResourceServer creates a new resource server (API/(micro-)service) in a project
 // @Summary Create resource server
 // @Description Create a new resource server
@@ -46,7 +40,7 @@ func CreateResourceServer(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	projectSlug := vars["projectSlug"]
 
-	requestDto := CreateResourceServerRequestDto{}
+	requestDto := api.CreateResourceServerRequestDto{}
 	err = json.NewDecoder(r.Body).Decode(&requestDto)
 	if err != nil {
 		utils.HandleHttpError(w, err)
@@ -124,8 +118,8 @@ func ListResourceServers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	items := utils.MapSlice(resourceServers.Items, func(x queries.ListResourceServersResponseItem) ListResourceServersResponseDto {
-		return ListResourceServersResponseDto{
+	items := utils.MapSlice(resourceServers.Items, func(x queries.ListResourceServersResponseItem) api.ListResourceServersResponseDto {
+		return api.ListResourceServersResponseDto{
 			Id:   x.Id,
 			Slug: x.Slug,
 			Name: x.Name,
@@ -193,7 +187,7 @@ func GetResourceServer(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 
-	err = json.NewEncoder(w).Encode(GetResourceServerResponseDto{
+	err = json.NewEncoder(w).Encode(api.GetResourceServerResponseDto{
 		Id:          resourceServer.Id,
 		Slug:        resourceServer.Slug,
 		Name:        resourceServer.Name,

--- a/internal/handlers/resourceservers.go
+++ b/internal/handlers/resourceservers.go
@@ -1,13 +1,13 @@
 package handlers
 
 import (
+	"github.com/The127/Keyline/api"
 	"github.com/The127/Keyline/internal/commands"
 	"github.com/The127/Keyline/internal/middlewares"
 	"github.com/The127/Keyline/internal/queries"
 	"github.com/The127/Keyline/utils"
 	"encoding/json"
 	"net/http"
-	"time"
 
 	"github.com/The127/ioc"
 	"github.com/The127/mediatr"
@@ -16,11 +16,11 @@ import (
 	"github.com/gorilla/mux"
 )
 
-type CreateResourceServerRequestDto struct {
-	Slug        string `json:"slug" validate:"required,min=1,max=255"`
-	Name        string `json:"name" validate:"required"`
-	Description string `json:"description"`
-}
+// Type aliases to keep handler code compiling.
+type CreateResourceServerRequestDto = api.CreateResourceServerRequestDto
+type PagedResourceServersResponseDto = api.PagedResourceServersResponseDto
+type ListResourceServersResponseDto = api.ListResourceServersResponseDto
+type GetResourceServerResponseDto = api.GetResourceServerResponseDto
 
 // CreateResourceServer creates a new resource server (API/(micro-)service) in a project
 // @Summary Create resource server
@@ -75,14 +75,6 @@ func CreateResourceServer(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusNoContent)
-}
-
-type PagedResourceServersResponseDto = PagedResponseDto[ListResourceServersResponseDto]
-
-type ListResourceServersResponseDto struct {
-	Id   uuid.UUID `json:"id"`
-	Slug string    `json:"slug"`
-	Name string    `json:"name"`
 }
 
 // ListResourceServers lists resource servers in a project
@@ -151,15 +143,6 @@ func ListResourceServers(w http.ResponseWriter, r *http.Request) {
 		utils.HandleHttpError(w, err)
 		return
 	}
-}
-
-type GetResourceServerResponseDto struct {
-	Id          uuid.UUID `json:"id"`
-	Slug        string    `json:"slug"`
-	Name        string    `json:"name"`
-	Description string    `json:"description"`
-	CreatedAt   time.Time `json:"createdAt"`
-	UpdatedAt   time.Time `json:"updatedAt"`
 }
 
 // GetResourceServer retrieves details of a specific resource server by ID

--- a/internal/handlers/resourceserverscopes.go
+++ b/internal/handlers/resourceserverscopes.go
@@ -16,13 +16,6 @@ import (
 	"github.com/gorilla/mux"
 )
 
-// Type aliases to keep handler code compiling.
-type CreateResourceServerScopeRequestDto = api.CreateResourceServerScopeRequestDto
-type CreateResourceServerScopeResponseDto = api.CreateResourceServerScopeResponseDto
-type PagedResourceServerScopeResponseDto = api.PagedResourceServerScopeResponseDto
-type ListResourceServerScopesResponseDto = api.ListResourceServerScopesResponseDto
-type GetResourceServerScopeResponseDto = api.GetResourceServerScopeResponseDto
-
 // CreateResourceServerScope creates a new scope for a resource server
 // @Summary Create resource server scope
 // @Description Create a new scope for a resource server
@@ -56,7 +49,7 @@ func CreateResourceServerScope(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var dto CreateResourceServerScopeRequestDto
+	var dto api.CreateResourceServerScopeRequestDto
 	err = json.NewDecoder(r.Body).Decode(&dto)
 	if err != nil {
 		utils.HandleHttpError(w, err)
@@ -88,7 +81,7 @@ func CreateResourceServerScope(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 
-	err = json.NewEncoder(w).Encode(CreateResourceServerScopeResponseDto{
+	err = json.NewEncoder(w).Encode(api.CreateResourceServerScopeResponseDto{
 		Id: response.Id,
 	})
 	if err != nil {
@@ -155,8 +148,8 @@ func ListResourceServerScopes(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	items := utils.MapSlice(scopes.Items, func(x queries.ListResourceServerScopesResponseItem) ListResourceServerScopesResponseDto {
-		return ListResourceServerScopesResponseDto{
+	items := utils.MapSlice(scopes.Items, func(x queries.ListResourceServerScopesResponseItem) api.ListResourceServerScopesResponseDto {
+		return api.ListResourceServerScopesResponseDto{
 			Id:    x.Id,
 			Name:  x.Name,
 			Scope: x.Scope,
@@ -232,7 +225,7 @@ func GetResourceServerScope(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 
-	err = json.NewEncoder(w).Encode(GetResourceServerScopeResponseDto{
+	err = json.NewEncoder(w).Encode(api.GetResourceServerScopeResponseDto{
 		Id:          scopeResponse.Id,
 		Scope:       scopeResponse.Scope,
 		Name:        scopeResponse.Name,

--- a/internal/handlers/resourceserverscopes.go
+++ b/internal/handlers/resourceserverscopes.go
@@ -1,13 +1,13 @@
 package handlers
 
 import (
+	"github.com/The127/Keyline/api"
 	"github.com/The127/Keyline/internal/commands"
 	"github.com/The127/Keyline/internal/middlewares"
 	"github.com/The127/Keyline/internal/queries"
 	"github.com/The127/Keyline/utils"
 	"encoding/json"
 	"net/http"
-	"time"
 
 	"github.com/The127/ioc"
 	"github.com/The127/mediatr"
@@ -16,15 +16,12 @@ import (
 	"github.com/gorilla/mux"
 )
 
-type CreateResourceServerScopeRequestDto struct {
-	Scope       string `json:"scope" validate:"required,min=1,max=255"`
-	Name        string `json:"name" validate:"required,min=1,max=255"`
-	Description string `json:"description"`
-}
-
-type CreateResourceServerScopeResponseDto struct {
-	Id uuid.UUID `json:"id"`
-}
+// Type aliases to keep handler code compiling.
+type CreateResourceServerScopeRequestDto = api.CreateResourceServerScopeRequestDto
+type CreateResourceServerScopeResponseDto = api.CreateResourceServerScopeResponseDto
+type PagedResourceServerScopeResponseDto = api.PagedResourceServerScopeResponseDto
+type ListResourceServerScopesResponseDto = api.ListResourceServerScopesResponseDto
+type GetResourceServerScopeResponseDto = api.GetResourceServerScopeResponseDto
 
 // CreateResourceServerScope creates a new scope for a resource server
 // @Summary Create resource server scope
@@ -98,14 +95,6 @@ func CreateResourceServerScope(w http.ResponseWriter, r *http.Request) {
 		utils.HandleHttpError(w, err)
 		return
 	}
-}
-
-type PagedResourceServerScopeResponseDto = PagedResponseDto[ListResourceServerScopesResponseDto]
-
-type ListResourceServerScopesResponseDto struct {
-	Id    uuid.UUID `json:"id"`
-	Scope string    `json:"scope"`
-	Name  string    `json:"name"`
 }
 
 // ListResourceServerScopes lists resource server scopes
@@ -185,15 +174,6 @@ func ListResourceServerScopes(w http.ResponseWriter, r *http.Request) {
 		utils.HandleHttpError(w, err)
 		return
 	}
-}
-
-type GetResourceServerScopeResponseDto struct {
-	Id          uuid.UUID `json:"id"`
-	Scope       string    `json:"scope"`
-	Name        string    `json:"name"`
-	Description string    `json:"description"`
-	CreatedAt   time.Time `json:"createdAt"`
-	UpdatedAt   time.Time `json:"updatedAt"`
 }
 
 // GetResourceServerScope retrieves details of a specific resource server scope by ID

--- a/internal/handlers/roles.go
+++ b/internal/handlers/roles.go
@@ -1,13 +1,13 @@
 package handlers
 
 import (
+	"github.com/The127/Keyline/api"
 	"github.com/The127/Keyline/internal/commands"
 	"github.com/The127/Keyline/internal/middlewares"
 	"github.com/The127/Keyline/internal/queries"
 	"github.com/The127/Keyline/utils"
 	"encoding/json"
 	"net/http"
-	"time"
 
 	"github.com/The127/ioc"
 	"github.com/The127/mediatr"
@@ -16,13 +16,15 @@ import (
 	"github.com/gorilla/mux"
 )
 
-type GetRoleByIdResponseDto struct {
-	Id          uuid.UUID `json:"id"`
-	Name        string    `json:"name"`
-	Description string    `json:"description"`
-	CreatedAt   time.Time `json:"createdAt"`
-	UpdatedAt   time.Time `json:"updatedAt"`
-}
+// Type aliases to keep handler code compiling.
+type GetRoleByIdResponseDto = api.GetRoleByIdResponseDto
+type PagedRolesResponseDto = api.PagedRolesResponseDto
+type ListRolesResponseDto = api.ListRolesResponseDto
+type CreateRoleRequestDto = api.CreateRoleRequestDto
+type CreateRoleResponseDto = api.CreateRoleResponseDto
+type AssignRoleRequestDto = api.AssignRoleRequestDto
+type PagedUsersInRoleResponseDto = api.PagedUsersInRoleResponseDto
+type ListUsersInRoleResponseDto = api.ListUsersInRoleResponseDto
 
 // GetRoleById
 // @summary     Get role
@@ -84,16 +86,6 @@ func GetRoleById(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		utils.HandleHttpError(w, err)
 	}
-}
-
-type PagedRolesResponseDto struct {
-	Items      []ListRolesResponseDto `json:"items"`
-	Pagination Pagination             `json:"pagination"`
-}
-
-type ListRolesResponseDto struct {
-	Id   uuid.UUID `json:"id"`
-	Name string    `json:"name"`
 }
 
 // ListRoles
@@ -166,15 +158,6 @@ func ListRoles(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-type CreateRoleRequestDto struct {
-	Name        string `json:"name" validate:"required,min=1,max=255"`
-	Description string `json:"description" validate:"max=1024"`
-}
-
-type CreateRoleResponseDto struct {
-	Id uuid.UUID `json:"id"`
-}
-
 // CreateRole
 // @summary     Create role
 // @description Create a new role within a project.
@@ -235,10 +218,6 @@ func CreateRole(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		utils.HandleHttpError(w, err)
 	}
-}
-
-type AssignRoleRequestDto struct {
-	UserId uuid.UUID `json:"userId" validate:"required,uuid=4"`
 }
 
 // AssignRole
@@ -302,14 +281,6 @@ func AssignRole(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusNoContent)
-}
-
-type PagedUsersInRoleResponseDto = PagedResponseDto[ListUsersInRoleResponseDto]
-
-type ListUsersInRoleResponseDto struct {
-	Id          uuid.UUID `json:"id"`
-	Username    string    `json:"username"`
-	DisplayName string    `json:"displayName"`
 }
 
 // ListUsersInRole lists users in a role

--- a/internal/handlers/roles.go
+++ b/internal/handlers/roles.go
@@ -16,16 +16,6 @@ import (
 	"github.com/gorilla/mux"
 )
 
-// Type aliases to keep handler code compiling.
-type GetRoleByIdResponseDto = api.GetRoleByIdResponseDto
-type PagedRolesResponseDto = api.PagedRolesResponseDto
-type ListRolesResponseDto = api.ListRolesResponseDto
-type CreateRoleRequestDto = api.CreateRoleRequestDto
-type CreateRoleResponseDto = api.CreateRoleResponseDto
-type AssignRoleRequestDto = api.AssignRoleRequestDto
-type PagedUsersInRoleResponseDto = api.PagedUsersInRoleResponseDto
-type ListUsersInRoleResponseDto = api.ListUsersInRoleResponseDto
-
 // GetRoleById
 // @summary     Get role
 // @description Get a role by its ID within a project.
@@ -74,7 +64,7 @@ func GetRoleById(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 
-	response := GetRoleByIdResponseDto{
+	response := api.GetRoleByIdResponseDto{
 		Id:          queryResult.Id,
 		Name:        queryResult.Name,
 		Description: queryResult.Description,
@@ -137,8 +127,8 @@ func ListRoles(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	items := utils.MapSlice(roles.Items, func(x queries.ListRolesResponseItem) ListRolesResponseDto {
-		return ListRolesResponseDto{
+	items := utils.MapSlice(roles.Items, func(x queries.ListRolesResponseItem) api.ListRolesResponseDto {
+		return api.ListRolesResponseDto{
 			Id:   x.Id,
 			Name: x.Name,
 		}
@@ -182,7 +172,7 @@ func CreateRole(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	projectSlug := vars["projectSlug"]
 
-	var dto CreateRoleRequestDto
+	var dto api.CreateRoleRequestDto
 	err = json.NewDecoder(r.Body).Decode(&dto)
 	if err != nil {
 		utils.HandleHttpError(w, err)
@@ -212,7 +202,7 @@ func CreateRole(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 
-	err = json.NewEncoder(w).Encode(CreateRoleResponseDto{
+	err = json.NewEncoder(w).Encode(api.CreateRoleResponseDto{
 		Id: response.Id,
 	})
 	if err != nil {
@@ -253,7 +243,7 @@ func AssignRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var dto AssignRoleRequestDto
+	var dto api.AssignRoleRequestDto
 	err = json.NewDecoder(r.Body).Decode(&dto)
 	if err != nil {
 		utils.HandleHttpError(w, err)
@@ -340,8 +330,8 @@ func ListUsersInRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	items := utils.MapSlice(users.Items, func(x queries.ListUsersInRoleResponseItem) ListUsersInRoleResponseDto {
-		return ListUsersInRoleResponseDto{
+	items := utils.MapSlice(users.Items, func(x queries.ListUsersInRoleResponseItem) api.ListUsersInRoleResponseDto {
+		return api.ListUsersInRoleResponseDto{
 			Id:          x.Id,
 			Username:    x.Username,
 			DisplayName: x.DisplayName,

--- a/internal/handlers/templates.go
+++ b/internal/handlers/templates.go
@@ -15,11 +15,6 @@ import (
 	"github.com/gorilla/mux"
 )
 
-// Type aliases to keep handler code compiling.
-type PagedTemplatesResponseDto = api.PagedTemplatesResponseDto
-type GetTemplateResponseDto = api.GetTemplateResponseDto
-type ListTemplatesResponseDto = api.ListTemplatesResponseDto
-
 // GetTemplate returns a single template by type.
 // @Summary      Get template
 // @Tags         Templates
@@ -60,7 +55,7 @@ func GetTemplate(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 
-	response := GetTemplateResponseDto{
+	response := api.GetTemplateResponseDto{
 		Id:        queryResult.Id,
 		Type:      string(query.Type),
 		Text:      queryResult.Text,
@@ -111,8 +106,8 @@ func ListTemplates(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	items := utils.MapSlice(templates.Items, func(x queries.ListTemplatesResponseItem) ListTemplatesResponseDto {
-		return ListTemplatesResponseDto{
+	items := utils.MapSlice(templates.Items, func(x queries.ListTemplatesResponseItem) api.ListTemplatesResponseDto {
+		return api.ListTemplatesResponseDto{
 			Id:   x.Id,
 			Type: string(x.Type),
 		}

--- a/internal/handlers/templates.go
+++ b/internal/handlers/templates.go
@@ -1,33 +1,24 @@
 package handlers
 
 import (
+	"github.com/The127/Keyline/api"
 	"github.com/The127/Keyline/internal/middlewares"
 	"github.com/The127/Keyline/internal/queries"
 	"github.com/The127/Keyline/internal/repositories"
 	"github.com/The127/Keyline/utils"
 	"encoding/json"
 	"net/http"
-	"time"
 
 	"github.com/The127/ioc"
 	"github.com/The127/mediatr"
 
-	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 )
 
-// PagedTemplatesResponseDto is the paged envelope for ListTemplates.
-type PagedTemplatesResponseDto struct {
-	Items      []ListTemplatesResponseDto `json:"items"`
-	Pagination Pagination                 `json:"pagination"`
-}
-type GetTemplateResponseDto struct {
-	Id        uuid.UUID                 `json:"id"`
-	Type      repositories.TemplateType `json:"type"`
-	Text      string                    `json:"text"`
-	CreatedAt time.Time                 `json:"createdAt"`
-	UpdatedAt time.Time                 `json:"updatedAt"`
-}
+// Type aliases to keep handler code compiling.
+type PagedTemplatesResponseDto = api.PagedTemplatesResponseDto
+type GetTemplateResponseDto = api.GetTemplateResponseDto
+type ListTemplatesResponseDto = api.ListTemplatesResponseDto
 
 // GetTemplate returns a single template by type.
 // @Summary      Get template
@@ -71,7 +62,7 @@ func GetTemplate(w http.ResponseWriter, r *http.Request) {
 
 	response := GetTemplateResponseDto{
 		Id:        queryResult.Id,
-		Type:      query.Type,
+		Type:      string(query.Type),
 		Text:      queryResult.Text,
 		CreatedAt: queryResult.CreatedAt,
 		UpdatedAt: queryResult.UpdatedAt,
@@ -81,11 +72,6 @@ func GetTemplate(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		utils.HandleHttpError(w, err)
 	}
-}
-
-type ListTemplatesResponseDto struct {
-	Id   uuid.UUID                 `json:"id"`
-	Type repositories.TemplateType `json:"type"`
 }
 
 // ListTemplates lists available templates for the virtual server.
@@ -128,7 +114,7 @@ func ListTemplates(w http.ResponseWriter, r *http.Request) {
 	items := utils.MapSlice(templates.Items, func(x queries.ListTemplatesResponseItem) ListTemplatesResponseDto {
 		return ListTemplatesResponseDto{
 			Id:   x.Id,
-			Type: x.Type,
+			Type: string(x.Type),
 		}
 	})
 

--- a/internal/handlers/users.go
+++ b/internal/handlers/users.go
@@ -25,31 +25,6 @@ import (
 	"github.com/gorilla/mux"
 )
 
-// Type aliases to keep handler code compiling.
-type RegisterUserRequestDto = api.RegisterUserRequestDto
-type CreateUserRequestDto = api.CreateUserRequestDto
-type CreateUserRequestDtoPasword = api.CreateUserRequestDtoPasword
-type CreateUserResponseDto = api.CreateUserResponseDto
-type ListUsersResponseDto = api.ListUsersResponseDto
-type PagedUsersResponseDto = api.PagedUsersResponseDto
-type GetUserByIdResponseDto = api.GetUserByIdResponseDto
-type GetUserApplicationMetadataResponseDto = api.GetUserApplicationMetadataResponseDto
-type GetUserGlobalMetadataResponseDto = api.GetUserGlobalMetadataResponseDto
-type GetUserMetadataResponseDto = api.GetUserMetadataResponseDto
-type UpdateUserGlobalMetadataRequestDto = api.UpdateUserGlobalMetadataRequestDto
-type PatchUserGlobalMetadataRequestDto = api.PatchUserGlobalMetadataRequestDto
-type UpdateUserApplicationMetadataRequestDto = api.UpdateUserApplicationMetadataRequestDto
-type PatchUserApplicationMetadataRequestDto = api.PatchUserApplicationMetadataRequestDto
-type PatchUserRequestDto = api.PatchUserRequestDto
-type CreateServiceUserRequestDto = api.CreateServiceUserRequestDto
-type CreateServiceUserResponseDto = api.CreateServiceUserResponseDto
-type AssociateServiceUserPublicKeyRequestDto = api.AssociateServiceUserPublicKeyRequestDto
-type AssociateServiceUserPublicKeyResponseDto = api.AssociateServiceUserPublicKeyResponseDto
-type PasskeyCreateChallengeResponseDto = api.PasskeyCreateChallengeResponseDto
-type PasskeyValidateChallengeRequestDto = api.PasskeyValidateChallengeRequestDto
-type ListPasskeyResponseDto = api.ListPasskeyResponseDto
-type PagedListPasskeyResponseDto = api.PagedListPasskeyResponseDto
-
 var (
 	ErrMissingEmailVerificationToken = fmt.Errorf("missing email verification token: %w", utils.ErrHttpBadRequest)
 )
@@ -110,7 +85,7 @@ func RegisterUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var dto RegisterUserRequestDto
+	var dto api.RegisterUserRequestDto
 	err = json.NewDecoder(r.Body).Decode(&dto)
 	if err != nil {
 		utils.HandleHttpError(w, err)
@@ -159,7 +134,7 @@ func CreateUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var dto CreateUserRequestDto
+	var dto api.CreateUserRequestDto
 	err = json.NewDecoder(r.Body).Decode(&dto)
 	if err != nil {
 		utils.HandleHttpError(w, err)
@@ -200,7 +175,7 @@ func CreateUser(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 
-	err = json.NewEncoder(w).Encode(CreateUserResponseDto{
+	err = json.NewEncoder(w).Encode(api.CreateUserResponseDto{
 		Id: createUserResponse.Id,
 	})
 	if err != nil {
@@ -249,8 +224,8 @@ func ListUsers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	items := utils.MapSlice(users.Items, func(x queries.ListUsersResponseItem) ListUsersResponseDto {
-		return ListUsersResponseDto{
+	items := utils.MapSlice(users.Items, func(x queries.ListUsersResponseItem) api.ListUsersResponseDto {
+		return api.ListUsersResponseDto{
 			Id:            x.Id,
 			Username:      x.Username,
 			DisplayName:   x.DisplayName,
@@ -314,7 +289,7 @@ func GetUserById(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 
-	response := GetUserByIdResponseDto{
+	response := api.GetUserByIdResponseDto{
 		Id:            queryResult.Id,
 		Username:      queryResult.Username,
 		DisplayName:   queryResult.DisplayName,
@@ -376,7 +351,7 @@ func GetUserApplicationMetadata(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var responseDto GetUserGlobalMetadataResponseDto = make(map[string]any)
+	var responseDto api.GetUserGlobalMetadataResponseDto = make(map[string]any)
 
 	for _, v := range response.ApplicationMetadata {
 		err := json.Unmarshal([]byte(v), &responseDto)
@@ -433,7 +408,7 @@ func GetUserGlobalMetadata(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var responseDto GetUserGlobalMetadataResponseDto = make(map[string]any)
+	var responseDto api.GetUserGlobalMetadataResponseDto = make(map[string]any)
 
 	if response.Metadata != "" {
 		err := json.Unmarshal([]byte(response.Metadata), &responseDto)
@@ -490,7 +465,7 @@ func GetUserMetadata(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	responseDto := GetUserMetadataResponseDto{}
+	responseDto := api.GetUserMetadataResponseDto{}
 
 	if response.Metadata != "" {
 		err := json.Unmarshal([]byte(response.Metadata), &responseDto.Metadata)
@@ -548,7 +523,7 @@ func UpdateUserGlobalMetadata(w http.ResponseWriter, r *http.Request) {
 		utils.HandleHttpError(w, utils.ErrInvalidUuid)
 	}
 
-	var dto UpdateUserGlobalMetadataRequestDto
+	var dto api.UpdateUserGlobalMetadataRequestDto
 	err = json.NewDecoder(r.Body).Decode(&dto)
 	if err != nil {
 		utils.HandleHttpError(w, err)
@@ -598,7 +573,7 @@ func PatchUserGlobalMetadata(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var dto PatchUserGlobalMetadataRequestDto
+	var dto api.PatchUserGlobalMetadataRequestDto
 	err = json.NewDecoder(r.Body).Decode(&dto)
 	if err != nil {
 		utils.HandleHttpError(w, err)
@@ -653,7 +628,7 @@ func UpdateUserApplicationMetadata(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var dto UpdateUserApplicationMetadataRequestDto
+	var dto api.UpdateUserApplicationMetadataRequestDto
 	err = json.NewDecoder(r.Body).Decode(&dto)
 	if err != nil {
 		utils.HandleHttpError(w, err)
@@ -711,7 +686,7 @@ func PatchUserApplicationMetadata(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var dto PatchUserApplicationMetadataRequestDto
+	var dto api.PatchUserApplicationMetadataRequestDto
 	err = json.NewDecoder(r.Body).Decode(&dto)
 	if err != nil {
 		utils.HandleHttpError(w, err)
@@ -761,7 +736,7 @@ func PatchUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var dto PatchUserRequestDto
+	var dto api.PatchUserRequestDto
 	err = json.NewDecoder(r.Body).Decode(&dto)
 	if err != nil {
 		utils.HandleHttpError(w, err)
@@ -803,7 +778,7 @@ func CreateServiceUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var dto CreateServiceUserRequestDto
+	var dto api.CreateServiceUserRequestDto
 	err = json.NewDecoder(r.Body).Decode(&dto)
 	if err != nil {
 		utils.HandleHttpError(w, err)
@@ -828,7 +803,7 @@ func CreateServiceUser(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 
-	err = json.NewEncoder(w).Encode(CreateServiceUserResponseDto{
+	err = json.NewEncoder(w).Encode(api.CreateServiceUserResponseDto{
 		Id: response.Id,
 	})
 	if err != nil {
@@ -862,7 +837,7 @@ func AssociateServiceUserPublicKey(w http.ResponseWriter, r *http.Request) {
 		utils.HandleHttpError(w, utils.ErrInvalidUuid)
 	}
 
-	var dto AssociateServiceUserPublicKeyRequestDto
+	var dto api.AssociateServiceUserPublicKeyRequestDto
 	err = json.NewDecoder(r.Body).Decode(&dto)
 	if err != nil {
 		utils.HandleHttpError(w, err)
@@ -888,7 +863,7 @@ func AssociateServiceUserPublicKey(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 
-	err = json.NewEncoder(w).Encode(AssociateServiceUserPublicKeyResponseDto{
+	err = json.NewEncoder(w).Encode(api.AssociateServiceUserPublicKeyResponseDto{
 		Kid: response.Kid,
 	})
 	if err != nil {
@@ -945,7 +920,7 @@ func PasskeyCreateChallenge(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 
-	err = json.NewEncoder(w).Encode(PasskeyCreateChallengeResponseDto{
+	err = json.NewEncoder(w).Encode(api.PasskeyCreateChallengeResponseDto{
 		Id:          challenge.Id,
 		Challenge:   challenge.Challenge,
 		UserId:      userId,
@@ -977,7 +952,7 @@ func PasskeyValidateCreateChallengeResponse(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	var dto PasskeyValidateChallengeRequestDto
+	var dto api.PasskeyValidateChallengeRequestDto
 	err = json.NewDecoder(r.Body).Decode(&dto)
 	if err != nil {
 		utils.HandleHttpError(w, err)
@@ -1041,15 +1016,15 @@ func ListPasskeys(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	items := utils.MapSlice(passkeys.Items, func(x queries.ListPasskeysResponseItem) ListPasskeyResponseDto {
-		return ListPasskeyResponseDto{
+	items := utils.MapSlice(passkeys.Items, func(x queries.ListPasskeysResponseItem) api.ListPasskeyResponseDto {
+		return api.ListPasskeyResponseDto{
 			Id: x.Id,
 		}
 	})
 
 	w.Header().Set("Content-Type", "application/json")
 
-	err = json.NewEncoder(w).Encode(PagedListPasskeyResponseDto{
+	err = json.NewEncoder(w).Encode(api.PagedListPasskeyResponseDto{
 		Items: items,
 	})
 	if err != nil {

--- a/internal/handlers/users.go
+++ b/internal/handlers/users.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"github.com/The127/Keyline/api"
 	"github.com/The127/Keyline/internal/authentication"
 	"github.com/The127/Keyline/internal/commands"
 	"github.com/The127/Keyline/internal/config"
@@ -23,6 +24,31 @@ import (
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 )
+
+// Type aliases to keep handler code compiling.
+type RegisterUserRequestDto = api.RegisterUserRequestDto
+type CreateUserRequestDto = api.CreateUserRequestDto
+type CreateUserRequestDtoPasword = api.CreateUserRequestDtoPasword
+type CreateUserResponseDto = api.CreateUserResponseDto
+type ListUsersResponseDto = api.ListUsersResponseDto
+type PagedUsersResponseDto = api.PagedUsersResponseDto
+type GetUserByIdResponseDto = api.GetUserByIdResponseDto
+type GetUserApplicationMetadataResponseDto = api.GetUserApplicationMetadataResponseDto
+type GetUserGlobalMetadataResponseDto = api.GetUserGlobalMetadataResponseDto
+type GetUserMetadataResponseDto = api.GetUserMetadataResponseDto
+type UpdateUserGlobalMetadataRequestDto = api.UpdateUserGlobalMetadataRequestDto
+type PatchUserGlobalMetadataRequestDto = api.PatchUserGlobalMetadataRequestDto
+type UpdateUserApplicationMetadataRequestDto = api.UpdateUserApplicationMetadataRequestDto
+type PatchUserApplicationMetadataRequestDto = api.PatchUserApplicationMetadataRequestDto
+type PatchUserRequestDto = api.PatchUserRequestDto
+type CreateServiceUserRequestDto = api.CreateServiceUserRequestDto
+type CreateServiceUserResponseDto = api.CreateServiceUserResponseDto
+type AssociateServiceUserPublicKeyRequestDto = api.AssociateServiceUserPublicKeyRequestDto
+type AssociateServiceUserPublicKeyResponseDto = api.AssociateServiceUserPublicKeyResponseDto
+type PasskeyCreateChallengeResponseDto = api.PasskeyCreateChallengeResponseDto
+type PasskeyValidateChallengeRequestDto = api.PasskeyValidateChallengeRequestDto
+type ListPasskeyResponseDto = api.ListPasskeyResponseDto
+type PagedListPasskeyResponseDto = api.PagedListPasskeyResponseDto
 
 var (
 	ErrMissingEmailVerificationToken = fmt.Errorf("missing email verification token: %w", utils.ErrHttpBadRequest)
@@ -63,13 +89,6 @@ func VerifyEmail(w http.ResponseWriter, r *http.Request) {
 	}
 
 	http.Redirect(w, r, fmt.Sprintf("%s/%s/email-verified", config.C.Frontend.ExternalUrl, vsName), http.StatusFound)
-}
-
-type RegisterUserRequestDto struct {
-	Username    string `json:"username" validate:"required,min=1,max=255"`
-	DisplayName string `json:"displayName" validate:"required,min=1,max=255"`
-	Password    string `json:"password" validate:"required"`
-	Email       string `json:"email" validate:"required"`
 }
 
 // RegisterUser registers a new user.
@@ -120,23 +139,6 @@ func RegisterUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusNoContent)
-}
-
-type CreateUserRequestDto struct {
-	Username      string                       `json:"username" validate:"required"`
-	DisplayName   string                       `json:"displayName" validate:"required"`
-	Email         string                       `json:"email" validate:"required"`
-	EmailVerified bool                         `json:"emailVerified" validate:"required"`
-	Password      *CreateUserRequestDtoPasword `json:"password"`
-}
-
-type CreateUserRequestDtoPasword struct {
-	Plain     string `json:"plain" validate:"required"`
-	Temporary bool   `json:"temporary"`
-}
-
-type CreateUserResponseDto struct {
-	Id uuid.UUID `json:"id"`
 }
 
 // CreateUser creates a new user.
@@ -207,19 +209,6 @@ func CreateUser(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-type ListUsersResponseDto struct {
-	Id            uuid.UUID `json:"id"`
-	Username      string    `json:"username"`
-	DisplayName   string    `json:"displayName"`
-	PrimaryEmail  string    `json:"primaryEmail"`
-	IsServiceUser bool      `json:"isServiceUser"`
-}
-
-type PagedUsersResponseDto struct {
-	Items      []ListUsersResponseDto `json:"items"`
-	Pagination Pagination             `json:"pagination"`
-}
-
 // ListUsers returns users with optional paging/search.
 // @Summary      List users
 // @Tags         Users
@@ -283,17 +272,6 @@ func ListUsers(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-type GetUserByIdResponseDto struct {
-	Id            uuid.UUID `json:"id"`
-	Username      string    `json:"username"`
-	DisplayName   string    `json:"displayName"`
-	PrimaryEmail  string    `json:"primaryEmail"`
-	EmailVerified bool      `json:"emailVerified"`
-	IsServiceUser bool      `json:"isServiceUser"`
-	CreatedAt     time.Time `json:"createdAt"`
-	UpdatedAt     time.Time `json:"updatedAt"`
-}
-
 // GetUserById returns a user by ID.
 // @Summary      Get user
 // @Tags         Users
@@ -352,8 +330,6 @@ func GetUserById(w http.ResponseWriter, r *http.Request) {
 		utils.HandleHttpError(w, err)
 	}
 }
-
-type GetUserApplicationMetadataResponseDto map[string]any
 
 // GetUserApplicationMetadata returns a users application metadata.
 // @Summary      Get users application metadata
@@ -418,8 +394,6 @@ func GetUserApplicationMetadata(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-type GetUserGlobalMetadataResponseDto map[string]any
-
 // GetUserGlobalMetadata returns a users metadata (only the global metadata).
 // @Summary      Get user metadata (only global)
 // @Tags         Users
@@ -475,11 +449,6 @@ func GetUserGlobalMetadata(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		utils.HandleHttpError(w, err)
 	}
-}
-
-type GetUserMetadataResponseDto struct {
-	Metadata            map[string]any `json:"metadata,omitempty"`
-	ApplicationMetadata map[string]any `json:"applicationMetadata,omitempty"`
 }
 
 // GetUserMetadata returns a users metadata.
@@ -553,8 +522,6 @@ func GetUserMetadata(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-type UpdateUserGlobalMetadataRequestDto map[string]any
-
 // UpdateUserGlobalMetadata updates a users metadata.
 // @Summary      Update a user metadata
 // @Tags         Users
@@ -601,8 +568,6 @@ func UpdateUserGlobalMetadata(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusNoContent)
 }
-
-type PatchUserGlobalMetadataRequestDto map[string]any
 
 // PatchUserGlobalMetadata patch a users metadata.
 // @Summary      Patch a user metadata using JSON Merge Patch (RFC 7396)
@@ -653,8 +618,6 @@ func PatchUserGlobalMetadata(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 }
-
-type UpdateUserApplicationMetadataRequestDto map[string]any
 
 // UpdateUserApplicationMetadata updates a users application metadata.
 // @Summary      Update a users application metadata
@@ -711,8 +674,6 @@ func UpdateUserApplicationMetadata(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusNoContent)
 }
-
-type PatchUserApplicationMetadataRequestDto map[string]any
 
 // PatchUserApplicationMetadata patch a users application metadata.
 // @Summary      Patch a users application metadata using JSON Merge Patch (RFC 7396)
@@ -771,11 +732,6 @@ func PatchUserApplicationMetadata(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-type PatchUserRequestDto struct {
-	DisplayName   *string `json:"displayName"`
-	EmailVerified *bool   `json:"emailVerified"`
-}
-
 // PatchUser updates fields of a user.
 // @Summary      Patch user
 // @Tags         Users
@@ -826,14 +782,6 @@ func PatchUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusNoContent)
-}
-
-type CreateServiceUserRequestDto struct {
-	Username string `json:"username" validate:"required,min=1,max=255"`
-}
-
-type CreateServiceUserResponseDto struct {
-	Id uuid.UUID `json:"id"`
 }
 
 // CreateServiceUser create a service user.
@@ -887,14 +835,6 @@ func CreateServiceUser(w http.ResponseWriter, r *http.Request) {
 		utils.HandleHttpError(w, err)
 		return
 	}
-}
-
-type AssociateServiceUserPublicKeyRequestDto struct {
-	PublicKey string `json:"publicKey" validate:"required"`
-}
-
-type AssociateServiceUserPublicKeyResponseDto struct {
-	Kid string `json:"kid"`
 }
 
 // AssociateServiceUserPublicKey associates a public key with a service user.
@@ -955,14 +895,6 @@ func AssociateServiceUserPublicKey(w http.ResponseWriter, r *http.Request) {
 		utils.HandleHttpError(w, err)
 		return
 	}
-}
-
-type PasskeyCreateChallengeResponseDto struct {
-	Id          uuid.UUID `json:"id"`
-	Challenge   string    `json:"challenge" validate:"required"`
-	UserId      uuid.UUID `json:"userId"`
-	Username    string    `json:"username"`
-	DisplayName string    `json:"displayName"`
 }
 
 func PasskeyCreateChallenge(w http.ResponseWriter, r *http.Request) {
@@ -1026,24 +958,6 @@ func PasskeyCreateChallenge(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-type PasskeyValidateChallengeRequestDto struct {
-	Id               uuid.UUID `json:"id" validate:"required"`
-	WebauthnResponse struct {
-		Id       string `json:"id"`
-		RawId    string `json:"rawId"`
-		Response struct {
-			ClientDataJSON     string   `json:"clientDataJSON"`
-			AuthenticatorData  string   `json:"authenticatorData"`
-			Transports         []string `json:"transports"`
-			PublicKey          string   `json:"publicKey"`
-			PublicKeyAlgorithm int      `json:"publicKeyAlgorithm"`
-			AttestationObject  string   `json:"attestationObject"`
-		} `json:"response"`
-		AuthenticatorAttachment string `json:"authenticatorAttachment"`
-		Type                    string `json:"type"`
-	} `json:"webauthnResponse" validate:"required"`
-}
-
 func PasskeyValidateCreateChallengeResponse(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	scope := middlewares.GetScope(ctx)
@@ -1096,14 +1010,6 @@ func PasskeyValidateCreateChallengeResponse(w http.ResponseWriter, r *http.Reque
 	_ = kvStore.Delete(ctx, "passkey_challenge:"+dto.Id.String())
 
 	w.WriteHeader(http.StatusNoContent)
-}
-
-type ListPasskeyResponseDto struct {
-	Id uuid.UUID `json:"id"`
-}
-
-type PagedListPasskeyResponseDto struct {
-	Items []ListPasskeyResponseDto `json:"items"`
 }
 
 func ListPasskeys(w http.ResponseWriter, r *http.Request) {

--- a/internal/handlers/virtualServers.go
+++ b/internal/handlers/virtualServers.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"github.com/The127/Keyline/api"
 	"github.com/The127/Keyline/internal/commands"
 	"github.com/The127/Keyline/internal/config"
 	"github.com/The127/Keyline/internal/middlewares"
@@ -8,72 +9,22 @@ import (
 	"github.com/The127/Keyline/utils"
 	"encoding/json"
 	"net/http"
-	"time"
 
 	"github.com/The127/ioc"
 	"github.com/The127/mediatr"
-
-	"github.com/google/uuid"
 )
 
-type CreateVirtualServerRequestDtoAdminDto struct {
-	Username     string   `json:"username" validate:"required,min=1,max=255"`
-	DisplayName  string   `json:"displayName" validate:"required,min=1,max=255"`
-	PrimaryEmail string   `json:"primaryEmail" validate:"required,email"`
-	PasswordHash string   `json:"passwordHash" validate:"required"`
-	Roles        []string `json:"roles"`
-}
-
-type CreateVirtualServerRequestDtoServiceUserDto struct {
-	Username  string   `json:"username" validate:"required,min=1,max=255"`
-	Roles     []string `json:"roles"`
-	PublicKey struct {
-		Pem string `json:"pem" validate:"required"`
-		Kid string `json:"kid" validate:"required"`
-	} `json:"publicKey" validate:"required"`
-}
-
-type CreateVirtualServerRequestDtoProjectDtoRoleDto struct {
-	Name        string `json:"name" validate:"required,min=1,max=255"`
-	Description string `json:"description"`
-}
-
-type CreateVirtualServerRequestDtoProjectDtoApplicationDto struct {
-	Name           string   `json:"name" validate:"required,min=1,max=255"`
-	DisplayName    string   `json:"displayName" validate:"required,min=1,max=255"`
-	Type           string   `json:"type" validate:"required,oneof=public confidential"`
-	HashedSecret   *string  `json:"hashedSecret"`
-	RedirectUris   []string `json:"redirectUris" validate:"required,dive,url,min=1"`
-	PostLogoutUris []string `json:"postLogoutUris" validate:"dive,url"`
-}
-
-type CreateVirtualServerRequestDtoProjectDtoResourceServerDto struct {
-	Slug        string `json:"slug" validate:"required,min=1,max=255"`
-	Name        string `json:"name" validate:"required,min=1,max=255"`
-	Description string `json:"description"`
-}
-
-type CreateVirtualServerRequestDtoProjectDto struct {
-	Slug        string `json:"slug" validate:"required,min=1,max=255"`
-	Name        string `json:"name" validate:"required,min=1,max=255"`
-	Description string `json:"description"`
-
-	Roles           []CreateVirtualServerRequestDtoProjectDtoRoleDto           `json:"roles"`
-	Applications    []CreateVirtualServerRequestDtoProjectDtoApplicationDto    `json:"applications"`
-	ResourceServers []CreateVirtualServerRequestDtoProjectDtoResourceServerDto `json:"resourceServers"`
-}
-
-type CreateVirtualServerRequestDto struct {
-	Name               string  `json:"name" validate:"required,min=1,max=255,alphanum"`
-	DisplayName        string  `json:"displayName" validate:"required,min=1,max=255"`
-	EnableRegistration bool    `json:"enableRegistration"`
-	SigningAlgorithm   *string `json:"signingAlgorithm" validate:"oneof=RS256 EdDSA"`
-	Require2fa         bool    `json:"require2fa"`
-
-	Admin        *CreateVirtualServerRequestDtoAdminDto        `json:"admin"`
-	ServiceUsers []CreateVirtualServerRequestDtoServiceUserDto `json:"serviceUsers"`
-	Projects     []CreateVirtualServerRequestDtoProjectDto     `json:"projects"`
-}
+// Type aliases to keep handler code compiling.
+type CreateVirtualServerRequestDtoAdminDto = api.CreateVirtualServerRequestDtoAdminDto
+type CreateVirtualServerRequestDtoServiceUserDto = api.CreateVirtualServerRequestDtoServiceUserDto
+type CreateVirtualServerRequestDtoProjectDtoRoleDto = api.CreateVirtualServerRequestDtoProjectDtoRoleDto
+type CreateVirtualServerRequestDtoProjectDtoApplicationDto = api.CreateVirtualServerRequestDtoProjectDtoApplicationDto
+type CreateVirtualServerRequestDtoProjectDtoResourceServerDto = api.CreateVirtualServerRequestDtoProjectDtoResourceServerDto
+type CreateVirtualServerRequestDtoProjectDto = api.CreateVirtualServerRequestDtoProjectDto
+type CreateVirtualServerRequestDto = api.CreateVirtualServerRequestDto
+type GetVirtualServerResponseDto = api.GetVirtualServerResponseDto
+type GetVirtualServerListResponseDto = api.GetVirtualServerListResponseDto
+type PatchVirtualServerRequestDto = api.PatchVirtualServerRequestDto
 
 // CreateVirtualServer creates a new virtual server.
 // @Summary      Create virtual server
@@ -174,18 +125,6 @@ func CreateVirtualServer(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-type GetVirtualServerResponseDto struct {
-	Id                       uuid.UUID `json:"id"`
-	Name                     string    `json:"name"`
-	DisplayName              string    `json:"displayName"`
-	RegistrationEnabled      bool      `json:"registrationEnabled"`
-	Require2fa               bool      `json:"require2fa"`
-	RequireEmailVerification bool      `json:"requireEmailVerification"`
-	SigningAlgorithm         string    `json:"signingAlgorithm"`
-	CreatedAt                time.Time `json:"createdAt"`
-	UpdatedAt                time.Time `json:"updatedAt"`
-}
-
 // GetVirtualServer returns details of a virtual server.
 // @Summary      Get virtual server
 // @Tags         Admin
@@ -232,12 +171,6 @@ func GetVirtualServer(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-type GetVirtualServerListResponseDto struct {
-	Name                string `json:"name"`
-	DisplayName         string `json:"displayName"`
-	RegistrationEnabled bool   `json:"registrationEnabled"`
-}
-
 // GetVirtualServerPublicInfo returns public info of a virtual server.
 // @Summary      Get virtual server public info
 // @Tags         Admin
@@ -277,14 +210,6 @@ func GetVirtualServerPublicInfo(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		utils.HandleHttpError(w, err)
 	}
-}
-
-type PatchVirtualServerRequestDto struct {
-	DisplayName *string `json:"displayName"`
-
-	EnableRegistration       *bool `json:"enableRegistration"`
-	Require2fa               *bool `json:"require2fa"`
-	RequireEmailVerification *bool `json:"requireEmailVerification"`
 }
 
 // PatchVirtualServer patches a virtual server.

--- a/internal/handlers/virtualServers.go
+++ b/internal/handlers/virtualServers.go
@@ -14,18 +14,6 @@ import (
 	"github.com/The127/mediatr"
 )
 
-// Type aliases to keep handler code compiling.
-type CreateVirtualServerRequestDtoAdminDto = api.CreateVirtualServerRequestDtoAdminDto
-type CreateVirtualServerRequestDtoServiceUserDto = api.CreateVirtualServerRequestDtoServiceUserDto
-type CreateVirtualServerRequestDtoProjectDtoRoleDto = api.CreateVirtualServerRequestDtoProjectDtoRoleDto
-type CreateVirtualServerRequestDtoProjectDtoApplicationDto = api.CreateVirtualServerRequestDtoProjectDtoApplicationDto
-type CreateVirtualServerRequestDtoProjectDtoResourceServerDto = api.CreateVirtualServerRequestDtoProjectDtoResourceServerDto
-type CreateVirtualServerRequestDtoProjectDto = api.CreateVirtualServerRequestDtoProjectDto
-type CreateVirtualServerRequestDto = api.CreateVirtualServerRequestDto
-type GetVirtualServerResponseDto = api.GetVirtualServerResponseDto
-type GetVirtualServerListResponseDto = api.GetVirtualServerListResponseDto
-type PatchVirtualServerRequestDto = api.PatchVirtualServerRequestDto
-
 // CreateVirtualServer creates a new virtual server.
 // @Summary      Create virtual server
 // @Tags         Admin
@@ -39,7 +27,7 @@ func CreateVirtualServer(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	scope := middlewares.GetScope(ctx)
 
-	var dto CreateVirtualServerRequestDto
+	var dto api.CreateVirtualServerRequestDto
 	err := json.NewDecoder(r.Body).Decode(&dto)
 	if err != nil {
 		utils.HandleHttpError(w, err)
@@ -64,7 +52,7 @@ func CreateVirtualServer(w http.ResponseWriter, r *http.Request) {
 		EnableRegistration: dto.EnableRegistration,
 		SigningAlgorithm:   signingAlgorithm,
 		Require2fa:         dto.Require2fa,
-		Admin: utils.MapPtr(dto.Admin, func(admin CreateVirtualServerRequestDtoAdminDto) commands.CreateVirtualServerAdmin {
+		Admin: utils.MapPtr(dto.Admin, func(admin api.CreateVirtualServerRequestDtoAdminDto) commands.CreateVirtualServerAdmin {
 			return commands.CreateVirtualServerAdmin{
 				Username:     admin.Username,
 				DisplayName:  admin.DisplayName,
@@ -73,7 +61,7 @@ func CreateVirtualServer(w http.ResponseWriter, r *http.Request) {
 				Roles:        admin.Roles,
 			}
 		}),
-		ServiceUsers: utils.MapSlice(dto.ServiceUsers, func(x CreateVirtualServerRequestDtoServiceUserDto) commands.CreateVirtualServerServiceUser {
+		ServiceUsers: utils.MapSlice(dto.ServiceUsers, func(x api.CreateVirtualServerRequestDtoServiceUserDto) commands.CreateVirtualServerServiceUser {
 			return commands.CreateVirtualServerServiceUser{
 				Username: x.Username,
 				Roles:    x.Roles,
@@ -86,12 +74,12 @@ func CreateVirtualServer(w http.ResponseWriter, r *http.Request) {
 				},
 			}
 		}),
-		Projects: utils.MapSlice(dto.Projects, func(project CreateVirtualServerRequestDtoProjectDto) commands.CreateVirtualServerProject {
+		Projects: utils.MapSlice(dto.Projects, func(project api.CreateVirtualServerRequestDtoProjectDto) commands.CreateVirtualServerProject {
 			return commands.CreateVirtualServerProject{
 				Slug:        project.Slug,
 				Name:        project.Name,
 				Description: project.Description,
-				Applications: utils.MapSlice(project.Applications, func(app CreateVirtualServerRequestDtoProjectDtoApplicationDto) commands.CreateVirtualServerProjectApplication {
+				Applications: utils.MapSlice(project.Applications, func(app api.CreateVirtualServerRequestDtoProjectDtoApplicationDto) commands.CreateVirtualServerProjectApplication {
 					return commands.CreateVirtualServerProjectApplication{
 						Name:           app.Name,
 						DisplayName:    app.DisplayName,
@@ -101,13 +89,13 @@ func CreateVirtualServer(w http.ResponseWriter, r *http.Request) {
 						PostLogoutUris: app.PostLogoutUris,
 					}
 				}),
-				Roles: utils.MapSlice(project.Roles, func(role CreateVirtualServerRequestDtoProjectDtoRoleDto) commands.CreateVirtualServerProjectRole {
+				Roles: utils.MapSlice(project.Roles, func(role api.CreateVirtualServerRequestDtoProjectDtoRoleDto) commands.CreateVirtualServerProjectRole {
 					return commands.CreateVirtualServerProjectRole{
 						Name:        role.Name,
 						Description: role.Description,
 					}
 				}),
-				ResourceServers: utils.MapSlice(project.ResourceServers, func(rs CreateVirtualServerRequestDtoProjectDtoResourceServerDto) commands.CreateVirtualServerProjectResourceServer {
+				ResourceServers: utils.MapSlice(project.ResourceServers, func(rs api.CreateVirtualServerRequestDtoProjectDtoResourceServerDto) commands.CreateVirtualServerProjectResourceServer {
 					return commands.CreateVirtualServerProjectResourceServer{
 						Slug:        rs.Slug,
 						Name:        rs.Name,
@@ -155,7 +143,7 @@ func GetVirtualServer(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 
-	err = json.NewEncoder(w).Encode(GetVirtualServerResponseDto{
+	err = json.NewEncoder(w).Encode(api.GetVirtualServerResponseDto{
 		Id:                       response.Id,
 		Name:                     response.Name,
 		DisplayName:              response.DisplayName,
@@ -202,7 +190,7 @@ func GetVirtualServerPublicInfo(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 
-	err = json.NewEncoder(w).Encode(GetVirtualServerListResponseDto{
+	err = json.NewEncoder(w).Encode(api.GetVirtualServerListResponseDto{
 		Name:                response.Name,
 		DisplayName:         response.DisplayName,
 		RegistrationEnabled: response.RegistrationEnabled,
@@ -232,7 +220,7 @@ func PatchVirtualServer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var dto PatchVirtualServerRequestDto
+	var dto api.PatchVirtualServerRequestDto
 	err = json.NewDecoder(r.Body).Decode(&dto)
 	if err != nil {
 		utils.HandleHttpError(w, err)


### PR DESCRIPTION
## Summary

- Extracts all HTTP request/response DTOs from `internal/handlers` into a new public `api/` package, making them importable by external consumers (e.g. keyline-operator)
- Keeps type aliases in `internal/handlers` so all existing handler code compiles unchanged
- Updates `client/` to import from `api/` instead of `internal/handlers`
- Refactors `VirtualServerClient`: `Get` returns `VirtualServerState`, `Patch` takes `PatchVirtualServerInput` (client-owned types, no internal dependency)
- Adds `ProjectClient` with `Create` and `Get` methods
- Wires `Project()` into the main `Client` interface

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./client/...` passes