### PR TITLE
feat: add in-memory database backend for testing

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,7 @@ type DatabaseMode string
 const (
 	DatabaseModePostgres DatabaseMode = "postgres"
 	DatabaseModeSqlite   DatabaseMode = "sqlite"
+	DatabaseModeMemory   DatabaseMode = "memory"
 )
 
 // CacheMode has the following constants: CacheModeMemory, CacheModeRedis
@@ -569,6 +570,9 @@ func setDatabaseDefaultsOrPanic() {
 
 	case DatabaseModeSqlite:
 		setSqliteDefaultsOrPanic()
+
+	case DatabaseModeMemory:
+		// no-op: in-memory database has no connection parameters
 
 	default:
 		panic("database mode missing or not supported")

--- a/internal/database/memory/context.go
+++ b/internal/database/memory/context.go
@@ -1,0 +1,339 @@
+package memory
+
+import (
+	"github.com/The127/Keyline/internal/change"
+	db "github.com/The127/Keyline/internal/database"
+	"github.com/The127/Keyline/internal/repositories"
+	memrepos "github.com/The127/Keyline/internal/repositories/memory"
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+type Context struct {
+	stores        *Stores
+	changeTracker *change.Tracker
+
+	applications            *memrepos.ApplicationRepository
+	applicationUserMetadata *memrepos.ApplicationUserMetadataRepository
+	auditLogs               *memrepos.AuditLogRepository
+	credentials             *memrepos.CredentialRepository
+	files                   *memrepos.FileRepository
+	groupRoles              *memrepos.GroupRoleRepository
+	groups                  *memrepos.GroupRepository
+	outboxMessages          *memrepos.OutboxMessageRepository
+	passwordRules           *memrepos.PasswordRuleRepository
+	projects                *memrepos.ProjectRepository
+	resourceServers         *memrepos.ResourceServerRepository
+	resourceServerScopes    *memrepos.ResourceServerScopeRepository
+	roles                   *memrepos.RoleRepository
+	sessions                *memrepos.SessionRepository
+	templates               *memrepos.TemplateRepository
+	userRoleAssignments     *memrepos.UserRoleAssignmentRepository
+	users                   *memrepos.UserRepository
+	virtualServers          *memrepos.VirtualServerRepository
+}
+
+func newContext(stores *Stores) *Context {
+	return &Context{
+		stores:        stores,
+		changeTracker: change.NewTracker(),
+	}
+}
+
+func (c *Context) Applications() repositories.ApplicationRepository {
+	if c.applications == nil {
+		c.applications = memrepos.NewApplicationRepository(c.stores.Applications, &c.stores.mu, c.changeTracker, db.ApplicationEntityType)
+	}
+	return c.applications
+}
+
+func (c *Context) ApplicationUserMetadata() repositories.ApplicationUserMetadataRepository {
+	if c.applicationUserMetadata == nil {
+		c.applicationUserMetadata = memrepos.NewApplicationUserMetadataRepository(c.stores.ApplicationUserMetadata, &c.stores.mu, c.changeTracker, db.ApplicationUserMetadataEntityType)
+	}
+	return c.applicationUserMetadata
+}
+
+func (c *Context) AuditLogs() repositories.AuditLogRepository {
+	if c.auditLogs == nil {
+		c.auditLogs = memrepos.NewAuditLogRepository(c.stores.AuditLogs, &c.stores.mu, c.changeTracker, db.AuditLogEntityType)
+	}
+	return c.auditLogs
+}
+
+func (c *Context) Credentials() repositories.CredentialRepository {
+	if c.credentials == nil {
+		c.credentials = memrepos.NewCredentialRepository(c.stores.Credentials, &c.stores.mu, c.changeTracker, db.CredentialEntityType)
+	}
+	return c.credentials
+}
+
+func (c *Context) Files() repositories.FileRepository {
+	if c.files == nil {
+		c.files = memrepos.NewFileRepository(c.stores.Files, &c.stores.mu, c.changeTracker, db.FileEntityType)
+	}
+	return c.files
+}
+
+func (c *Context) GroupRoles() repositories.GroupRoleRepository {
+	if c.groupRoles == nil {
+		c.groupRoles = memrepos.NewGroupRoleRepository(c.stores.GroupRoles, &c.stores.mu, c.changeTracker, db.GroupRoleEntityType)
+	}
+	return c.groupRoles
+}
+
+func (c *Context) Groups() repositories.GroupRepository {
+	if c.groups == nil {
+		c.groups = memrepos.NewGroupRepository(c.stores.Groups, &c.stores.mu, c.changeTracker, db.GroupEntityType)
+	}
+	return c.groups
+}
+
+func (c *Context) OutboxMessages() repositories.OutboxMessageRepository {
+	if c.outboxMessages == nil {
+		c.outboxMessages = memrepos.NewOutboxMessageRepository(c.stores.OutboxMessages, &c.stores.mu, c.changeTracker, db.OutboxMessageEntityType)
+	}
+	return c.outboxMessages
+}
+
+func (c *Context) PasswordRules() repositories.PasswordRuleRepository {
+	if c.passwordRules == nil {
+		c.passwordRules = memrepos.NewPasswordRuleRepository(c.stores.PasswordRules, &c.stores.mu, c.changeTracker, db.PasswordRuleEntityType)
+	}
+	return c.passwordRules
+}
+
+func (c *Context) Projects() repositories.ProjectRepository {
+	if c.projects == nil {
+		c.projects = memrepos.NewProjectRepository(c.stores.Projects, &c.stores.mu, c.changeTracker, db.ProjectEntityType)
+	}
+	return c.projects
+}
+
+func (c *Context) ResourceServers() repositories.ResourceServerRepository {
+	if c.resourceServers == nil {
+		c.resourceServers = memrepos.NewResourceServerRepository(c.stores.ResourceServers, &c.stores.mu, c.changeTracker, db.ResourceServerEntityType)
+	}
+	return c.resourceServers
+}
+
+func (c *Context) ResourceServerScopes() repositories.ResourceServerScopeRepository {
+	if c.resourceServerScopes == nil {
+		c.resourceServerScopes = memrepos.NewResourceServerScopeRepository(c.stores.ResourceServerScopes, &c.stores.mu, c.changeTracker, db.ResourceServerScopeEntityType)
+	}
+	return c.resourceServerScopes
+}
+
+func (c *Context) Roles() repositories.RoleRepository {
+	if c.roles == nil {
+		c.roles = memrepos.NewRoleRepository(c.stores.Roles, &c.stores.mu, c.changeTracker, db.RoleEntityType)
+	}
+	return c.roles
+}
+
+func (c *Context) Sessions() repositories.SessionRepository {
+	if c.sessions == nil {
+		c.sessions = memrepos.NewSessionRepository(c.stores.Sessions, &c.stores.mu, c.changeTracker, db.SessionEntityType)
+	}
+	return c.sessions
+}
+
+func (c *Context) Templates() repositories.TemplateRepository {
+	if c.templates == nil {
+		c.templates = memrepos.NewTemplateRepository(c.stores.Templates, &c.stores.mu, c.changeTracker, db.TemplateEntityType)
+	}
+	return c.templates
+}
+
+func (c *Context) UserRoleAssignments() repositories.UserRoleAssignmentRepository {
+	if c.userRoleAssignments == nil {
+		c.userRoleAssignments = memrepos.NewUserRoleAssignmentRepository(
+			c.stores.UserRoleAssignments,
+			c.stores.Users,
+			c.stores.Roles,
+			c.stores.Projects,
+			&c.stores.mu,
+			c.changeTracker,
+			db.UserRoleAssignmentEntityType,
+		)
+	}
+	return c.userRoleAssignments
+}
+
+func (c *Context) Users() repositories.UserRepository {
+	if c.users == nil {
+		c.users = memrepos.NewUserRepository(c.stores.Users, &c.stores.mu, c.changeTracker, db.UserEntityType)
+	}
+	return c.users
+}
+
+func (c *Context) VirtualServers() repositories.VirtualServerRepository {
+	if c.virtualServers == nil {
+		c.virtualServers = memrepos.NewVirtualServerRepository(c.stores.VirtualServers, &c.stores.mu, c.changeTracker, db.VirtualServerEntityType)
+	}
+	return c.virtualServers
+}
+
+func (c *Context) SaveChanges(_ context.Context) error {
+	c.stores.mu.Lock()
+	defer c.stores.mu.Unlock()
+
+	for _, ch := range c.changeTracker.GetChanges() {
+		if err := c.applyChange(ch); err != nil {
+			return fmt.Errorf("applying change: %w", err)
+		}
+	}
+
+	c.changeTracker.Clear()
+	return nil
+}
+
+func (c *Context) applyChange(ch *change.Entry) error {
+	switch ch.GetItemType() {
+	case db.ApplicationEntityType:
+		return applyChange(c.stores.Applications, ch, func(e *repositories.Application) { e.SetVersion(incrementVersion(e.GetVersion())); e.ClearChanges() })
+
+	case db.ApplicationUserMetadataEntityType:
+		return applyChange(c.stores.ApplicationUserMetadata, ch, func(e *repositories.ApplicationUserMetadata) { e.SetVersion(incrementVersion(e.GetVersion())); e.ClearChanges() })
+
+	case db.AuditLogEntityType:
+		return applyInsertOnly(c.stores.AuditLogs, ch, func(e *repositories.AuditLog) { e.SetVersion(1) })
+
+	case db.CredentialEntityType:
+		return applyChange(c.stores.Credentials, ch, func(e *repositories.Credential) { e.SetVersion(incrementVersion(e.GetVersion())); e.ClearChanges() })
+
+	case db.FileEntityType:
+		return applyInsertOnly(c.stores.Files, ch, func(e *repositories.File) { e.SetVersion(1) })
+
+	case db.GroupRoleEntityType:
+		return fmt.Errorf("unsupported change type for group role: %v", ch.GetChangeType())
+
+	case db.GroupEntityType:
+		return applyChange(c.stores.Groups, ch, func(e *repositories.Group) { e.SetVersion(incrementVersion(e.GetVersion())); e.ClearChanges() })
+
+	case db.OutboxMessageEntityType:
+		return applyOutboxMessageChange(c.stores.OutboxMessages, ch)
+
+	case db.PasswordRuleEntityType:
+		return applyChange(c.stores.PasswordRules, ch, func(e *repositories.PasswordRule) { e.SetVersion(incrementVersion(e.GetVersion())); e.ClearChanges() })
+
+	case db.ProjectEntityType:
+		return applyChange(c.stores.Projects, ch, func(e *repositories.Project) { e.SetVersion(incrementVersion(e.GetVersion())); e.ClearChanges() })
+
+	case db.ResourceServerEntityType:
+		return applyChange(c.stores.ResourceServers, ch, func(e *repositories.ResourceServer) { e.SetVersion(incrementVersion(e.GetVersion())); e.ClearChanges() })
+
+	case db.ResourceServerScopeEntityType:
+		return applyChange(c.stores.ResourceServerScopes, ch, func(e *repositories.ResourceServerScope) { e.SetVersion(incrementVersion(e.GetVersion())); e.ClearChanges() })
+
+	case db.RoleEntityType:
+		return applyChange(c.stores.Roles, ch, func(e *repositories.Role) { e.SetVersion(incrementVersion(e.GetVersion())); e.ClearChanges() })
+
+	case db.SessionEntityType:
+		return applySessionChange(c.stores.Sessions, ch)
+
+	case db.TemplateEntityType:
+		return applyInsertOnly(c.stores.Templates, ch, func(e *repositories.Template) { e.SetVersion(1) })
+
+	case db.UserRoleAssignmentEntityType:
+		return applyInsertOnly(c.stores.UserRoleAssignments, ch, func(e *repositories.UserRoleAssignment) { e.SetVersion(1) })
+
+	case db.UserEntityType:
+		return applyChange(c.stores.Users, ch, func(e *repositories.User) { e.SetVersion(incrementVersion(e.GetVersion())); e.ClearChanges() })
+
+	case db.VirtualServerEntityType:
+		return applyChange(c.stores.VirtualServers, ch, func(e *repositories.VirtualServer) { e.SetVersion(incrementVersion(e.GetVersion())); e.ClearChanges() })
+
+	default:
+		return fmt.Errorf("unsupported item type: %v", ch.GetItemType())
+	}
+}
+
+func incrementVersion(v any) int {
+	if v == nil {
+		return 1
+	}
+	if i, ok := v.(int); ok {
+		return i + 1
+	}
+	return 1
+}
+
+type entityWithId interface {
+	Id() uuid.UUID
+}
+
+func applyChange[T entityWithId](store map[uuid.UUID]T, ch *change.Entry, onWrite func(T)) error {
+	switch ch.GetChangeType() {
+	case change.Added:
+		entity := ch.GetItem().(T)
+		onWrite(entity)
+		store[entity.Id()] = entity
+		return nil
+
+	case change.Updated:
+		entity := ch.GetItem().(T)
+		onWrite(entity)
+		store[entity.Id()] = entity
+		return nil
+
+	case change.Deleted:
+		id := ch.GetItem().(uuid.UUID)
+		delete(store, id)
+		return nil
+
+	default:
+		return fmt.Errorf("unsupported change type: %v", ch.GetChangeType())
+	}
+}
+
+func applyInsertOnly[T entityWithId](store map[uuid.UUID]T, ch *change.Entry, onInsert func(T)) error {
+	switch ch.GetChangeType() {
+	case change.Added:
+		entity := ch.GetItem().(T)
+		onInsert(entity)
+		store[entity.Id()] = entity
+		return nil
+
+	default:
+		return fmt.Errorf("unsupported change type: %v", ch.GetChangeType())
+	}
+}
+
+func applyOutboxMessageChange(store map[uuid.UUID]*repositories.OutboxMessage, ch *change.Entry) error {
+	switch ch.GetChangeType() {
+	case change.Added:
+		entity := ch.GetItem().(*repositories.OutboxMessage)
+		entity.SetVersion(1)
+		store[entity.Id()] = entity
+		return nil
+
+	case change.Deleted:
+		id := ch.GetItem().(uuid.UUID)
+		delete(store, id)
+		return nil
+
+	default:
+		return fmt.Errorf("unsupported change type: %v", ch.GetChangeType())
+	}
+}
+
+func applySessionChange(store map[uuid.UUID]*repositories.Session, ch *change.Entry) error {
+	switch ch.GetChangeType() {
+	case change.Added:
+		entity := ch.GetItem().(*repositories.Session)
+		entity.SetVersion(1)
+		store[entity.Id()] = entity
+		return nil
+
+	case change.Deleted:
+		id := ch.GetItem().(uuid.UUID)
+		delete(store, id)
+		return nil
+
+	default:
+		return fmt.Errorf("unsupported change type: %v", ch.GetChangeType())
+	}
+}

--- a/internal/database/memory/database.go
+++ b/internal/database/memory/database.go
@@ -1,0 +1,79 @@
+package memory
+
+import (
+	db "github.com/The127/Keyline/internal/database"
+	"github.com/The127/Keyline/internal/repositories"
+	"context"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+// Stores holds all in-memory maps shared across context instances.
+type Stores struct {
+	mu sync.RWMutex
+
+	Applications            map[uuid.UUID]*repositories.Application
+	ApplicationUserMetadata map[uuid.UUID]*repositories.ApplicationUserMetadata
+	AuditLogs               map[uuid.UUID]*repositories.AuditLog
+	Credentials             map[uuid.UUID]*repositories.Credential
+	Files                   map[uuid.UUID]*repositories.File
+	GroupRoles              map[uuid.UUID]*repositories.GroupRole
+	Groups                  map[uuid.UUID]*repositories.Group
+	OutboxMessages          map[uuid.UUID]*repositories.OutboxMessage
+	PasswordRules           map[uuid.UUID]*repositories.PasswordRule
+	Projects                map[uuid.UUID]*repositories.Project
+	ResourceServers         map[uuid.UUID]*repositories.ResourceServer
+	ResourceServerScopes    map[uuid.UUID]*repositories.ResourceServerScope
+	Roles                   map[uuid.UUID]*repositories.Role
+	Sessions                map[uuid.UUID]*repositories.Session
+	Templates               map[uuid.UUID]*repositories.Template
+	UserRoleAssignments     map[uuid.UUID]*repositories.UserRoleAssignment
+	Users                   map[uuid.UUID]*repositories.User
+	VirtualServers          map[uuid.UUID]*repositories.VirtualServer
+}
+
+func newStores() *Stores {
+	return &Stores{
+		Applications:            make(map[uuid.UUID]*repositories.Application),
+		ApplicationUserMetadata: make(map[uuid.UUID]*repositories.ApplicationUserMetadata),
+		AuditLogs:               make(map[uuid.UUID]*repositories.AuditLog),
+		Credentials:             make(map[uuid.UUID]*repositories.Credential),
+		Files:                   make(map[uuid.UUID]*repositories.File),
+		GroupRoles:              make(map[uuid.UUID]*repositories.GroupRole),
+		Groups:                  make(map[uuid.UUID]*repositories.Group),
+		OutboxMessages:          make(map[uuid.UUID]*repositories.OutboxMessage),
+		PasswordRules:           make(map[uuid.UUID]*repositories.PasswordRule),
+		Projects:                make(map[uuid.UUID]*repositories.Project),
+		ResourceServers:         make(map[uuid.UUID]*repositories.ResourceServer),
+		ResourceServerScopes:    make(map[uuid.UUID]*repositories.ResourceServerScope),
+		Roles:                   make(map[uuid.UUID]*repositories.Role),
+		Sessions:                make(map[uuid.UUID]*repositories.Session),
+		Templates:               make(map[uuid.UUID]*repositories.Template),
+		UserRoleAssignments:     make(map[uuid.UUID]*repositories.UserRoleAssignment),
+		Users:                   make(map[uuid.UUID]*repositories.User),
+		VirtualServers:          make(map[uuid.UUID]*repositories.VirtualServer),
+	}
+}
+
+type memoryDatabase struct {
+	stores *Stores
+}
+
+func NewMemoryDatabase() db.Database {
+	return &memoryDatabase{
+		stores: newStores(),
+	}
+}
+
+func (d *memoryDatabase) Migrate(_ context.Context) error {
+	return nil
+}
+
+func (d *memoryDatabase) NewDbContext(_ context.Context) (db.Context, error) {
+	return newContext(d.stores), nil
+}
+
+func (d *memoryDatabase) Close() error {
+	return nil
+}

--- a/internal/repositories/memory/applications.go
+++ b/internal/repositories/memory/applications.go
@@ -65,7 +65,7 @@ func (r *ApplicationRepository) filtered(filter *repositories.ApplicationFilter)
 }
 
 func (r *ApplicationRepository) FirstOrErr(_ context.Context, filter *repositories.ApplicationFilter) (*repositories.Application, error) {
-	result, err := r.FirstOrNil(nil, filter)
+	result, err := r.FirstOrNil(context.TODO(), filter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repositories/memory/applications.go
+++ b/internal/repositories/memory/applications.go
@@ -1,0 +1,111 @@
+package memory
+
+import (
+	"github.com/The127/Keyline/internal/change"
+	"github.com/The127/Keyline/internal/repositories"
+	"github.com/The127/Keyline/utils"
+	"context"
+	"slices"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+type ApplicationRepository struct {
+	store         map[uuid.UUID]*repositories.Application
+	mu            *sync.RWMutex
+	changeTracker *change.Tracker
+	entityType    int
+}
+
+func NewApplicationRepository(store map[uuid.UUID]*repositories.Application, mu *sync.RWMutex, changeTracker *change.Tracker, entityType int) *ApplicationRepository {
+	return &ApplicationRepository{
+		store:         store,
+		mu:            mu,
+		changeTracker: changeTracker,
+		entityType:    entityType,
+	}
+}
+
+func (r *ApplicationRepository) matches(a *repositories.Application, filter *repositories.ApplicationFilter) bool {
+	if filter.HasId() && a.Id() != filter.GetId() {
+		return false
+	}
+	if filter.HasIds() {
+		if !slices.Contains(filter.GetIds(), a.Id()) {
+			return false
+		}
+	}
+	if filter.HasName() && a.Name() != filter.GetName() {
+		return false
+	}
+	if filter.HasVirtualServerId() && a.VirtualServerId() != filter.GetVirtualServerId() {
+		return false
+	}
+	if filter.HasProjectId() && a.ProjectId() != filter.GetProjectId() {
+		return false
+	}
+	if filter.HasSearch() {
+		sf := filter.GetSearch()
+		if !matchesSearch(a.Name(), sf) && !matchesSearch(a.DisplayName(), sf) {
+			return false
+		}
+	}
+	return true
+}
+
+func (r *ApplicationRepository) filtered(filter *repositories.ApplicationFilter) []*repositories.Application {
+	var result []*repositories.Application
+	for _, a := range r.store {
+		if r.matches(a, filter) {
+			result = append(result, a)
+		}
+	}
+	return result
+}
+
+func (r *ApplicationRepository) FirstOrErr(_ context.Context, filter *repositories.ApplicationFilter) (*repositories.Application, error) {
+	result, err := r.FirstOrNil(nil, filter)
+	if err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return nil, utils.ErrApplicationNotFound
+	}
+	return result, nil
+}
+
+func (r *ApplicationRepository) FirstOrNil(_ context.Context, filter *repositories.ApplicationFilter) (*repositories.Application, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	items := r.filtered(filter)
+	if len(items) == 0 {
+		return nil, nil
+	}
+	return items[0], nil
+}
+
+func (r *ApplicationRepository) List(_ context.Context, filter *repositories.ApplicationFilter) ([]*repositories.Application, int, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	items := r.filtered(filter)
+	total := len(items)
+	if filter.HasPagination() {
+		items = paginateSlice(items, filter.GetPagingInfo())
+	}
+	return items, total, nil
+}
+
+func (r *ApplicationRepository) Insert(application *repositories.Application) {
+	r.changeTracker.Add(change.NewEntry(change.Added, r.entityType, application))
+}
+
+func (r *ApplicationRepository) Update(application *repositories.Application) {
+	r.changeTracker.Add(change.NewEntry(change.Updated, r.entityType, application))
+}
+
+func (r *ApplicationRepository) Delete(id uuid.UUID) {
+	r.changeTracker.Add(change.NewEntry(change.Deleted, r.entityType, id))
+}

--- a/internal/repositories/memory/applications.go
+++ b/internal/repositories/memory/applications.go
@@ -64,8 +64,8 @@ func (r *ApplicationRepository) filtered(filter *repositories.ApplicationFilter)
 	return result
 }
 
-func (r *ApplicationRepository) FirstOrErr(_ context.Context, filter *repositories.ApplicationFilter) (*repositories.Application, error) {
-	result, err := r.FirstOrNil(context.TODO(), filter)
+func (r *ApplicationRepository) FirstOrErr(ctx context.Context, filter *repositories.ApplicationFilter) (*repositories.Application, error) {
+	result, err := r.FirstOrNil(ctx, filter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repositories/memory/applicationusermetadata.go
+++ b/internal/repositories/memory/applicationusermetadata.go
@@ -1,0 +1,91 @@
+package memory
+
+import (
+	"github.com/The127/Keyline/internal/change"
+	"github.com/The127/Keyline/internal/repositories"
+	"github.com/The127/Keyline/utils"
+	"context"
+	"slices"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+type ApplicationUserMetadataRepository struct {
+	store         map[uuid.UUID]*repositories.ApplicationUserMetadata
+	mu            *sync.RWMutex
+	changeTracker *change.Tracker
+	entityType    int
+}
+
+func NewApplicationUserMetadataRepository(store map[uuid.UUID]*repositories.ApplicationUserMetadata, mu *sync.RWMutex, changeTracker *change.Tracker, entityType int) *ApplicationUserMetadataRepository {
+	return &ApplicationUserMetadataRepository{
+		store:         store,
+		mu:            mu,
+		changeTracker: changeTracker,
+		entityType:    entityType,
+	}
+}
+
+func (r *ApplicationUserMetadataRepository) matches(m *repositories.ApplicationUserMetadata, filter *repositories.ApplicationUserMetadataFilter) bool {
+	if filter.HasApplicationId() && m.ApplicationId() != filter.GetApplicationId() {
+		return false
+	}
+	if filter.HasApplicationIds() {
+		if !slices.Contains(filter.GetApplicationIds(), m.ApplicationId()) {
+			return false
+		}
+	}
+	if filter.HasUserId() && m.UserId() != filter.GetUserId() {
+		return false
+	}
+	return true
+}
+
+func (r *ApplicationUserMetadataRepository) filtered(filter *repositories.ApplicationUserMetadataFilter) []*repositories.ApplicationUserMetadata {
+	var result []*repositories.ApplicationUserMetadata
+	for _, m := range r.store {
+		if r.matches(m, filter) {
+			result = append(result, m)
+		}
+	}
+	return result
+}
+
+func (r *ApplicationUserMetadataRepository) FirstOrErr(_ context.Context, filter *repositories.ApplicationUserMetadataFilter) (*repositories.ApplicationUserMetadata, error) {
+	result, err := r.FirstOrNil(nil, filter)
+	if err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return nil, utils.ErrUserApplicationMetadataNotFound
+	}
+	return result, nil
+}
+
+func (r *ApplicationUserMetadataRepository) FirstOrNil(_ context.Context, filter *repositories.ApplicationUserMetadataFilter) (*repositories.ApplicationUserMetadata, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	items := r.filtered(filter)
+	if len(items) == 0 {
+		return nil, nil
+	}
+	return items[0], nil
+}
+
+func (r *ApplicationUserMetadataRepository) List(_ context.Context, filter *repositories.ApplicationUserMetadataFilter) ([]*repositories.ApplicationUserMetadata, int, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	items := r.filtered(filter)
+	return items, len(items), nil
+}
+
+func (r *ApplicationUserMetadataRepository) Insert(m *repositories.ApplicationUserMetadata) {
+	r.changeTracker.Add(change.NewEntry(change.Added, r.entityType, m))
+}
+
+func (r *ApplicationUserMetadataRepository) Update(m *repositories.ApplicationUserMetadata) {
+	r.changeTracker.Add(change.NewEntry(change.Updated, r.entityType, m))
+}

--- a/internal/repositories/memory/applicationusermetadata.go
+++ b/internal/repositories/memory/applicationusermetadata.go
@@ -52,8 +52,8 @@ func (r *ApplicationUserMetadataRepository) filtered(filter *repositories.Applic
 	return result
 }
 
-func (r *ApplicationUserMetadataRepository) FirstOrErr(_ context.Context, filter *repositories.ApplicationUserMetadataFilter) (*repositories.ApplicationUserMetadata, error) {
-	result, err := r.FirstOrNil(context.TODO(), filter)
+func (r *ApplicationUserMetadataRepository) FirstOrErr(ctx context.Context, filter *repositories.ApplicationUserMetadataFilter) (*repositories.ApplicationUserMetadata, error) {
+	result, err := r.FirstOrNil(ctx, filter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repositories/memory/applicationusermetadata.go
+++ b/internal/repositories/memory/applicationusermetadata.go
@@ -53,7 +53,7 @@ func (r *ApplicationUserMetadataRepository) filtered(filter *repositories.Applic
 }
 
 func (r *ApplicationUserMetadataRepository) FirstOrErr(_ context.Context, filter *repositories.ApplicationUserMetadataFilter) (*repositories.ApplicationUserMetadata, error) {
-	result, err := r.FirstOrNil(nil, filter)
+	result, err := r.FirstOrNil(context.TODO(), filter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repositories/memory/auditlogs.go
+++ b/internal/repositories/memory/auditlogs.go
@@ -1,0 +1,60 @@
+package memory
+
+import (
+	"github.com/The127/Keyline/internal/change"
+	"github.com/The127/Keyline/internal/repositories"
+	"context"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+type AuditLogRepository struct {
+	store         map[uuid.UUID]*repositories.AuditLog
+	mu            *sync.RWMutex
+	changeTracker *change.Tracker
+	entityType    int
+}
+
+func NewAuditLogRepository(store map[uuid.UUID]*repositories.AuditLog, mu *sync.RWMutex, changeTracker *change.Tracker, entityType int) *AuditLogRepository {
+	return &AuditLogRepository{
+		store:         store,
+		mu:            mu,
+		changeTracker: changeTracker,
+		entityType:    entityType,
+	}
+}
+
+func (r *AuditLogRepository) matches(a *repositories.AuditLog, filter *repositories.AuditLogFilter) bool {
+	if filter.HasVirtualServerId() && a.VirtualServerId() != filter.GetVirtualServerId() {
+		return false
+	}
+	if filter.HasUserId() {
+		uid := filter.GetUserId()
+		if a.UserId() == nil || *a.UserId() != uid {
+			return false
+		}
+	}
+	return true
+}
+
+func (r *AuditLogRepository) List(_ context.Context, filter *repositories.AuditLogFilter) ([]*repositories.AuditLog, int, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var items []*repositories.AuditLog
+	for _, a := range r.store {
+		if r.matches(a, filter) {
+			items = append(items, a)
+		}
+	}
+	total := len(items)
+	if filter.HasPagination() {
+		items = paginateSlice(items, filter.GetPagingInfo())
+	}
+	return items, total, nil
+}
+
+func (r *AuditLogRepository) Insert(auditLog *repositories.AuditLog) {
+	r.changeTracker.Add(change.NewEntry(change.Added, r.entityType, auditLog))
+}

--- a/internal/repositories/memory/credentials.go
+++ b/internal/repositories/memory/credentials.go
@@ -81,7 +81,7 @@ func (r *CredentialRepository) filtered(filter *repositories.CredentialFilter) [
 }
 
 func (r *CredentialRepository) FirstOrErr(_ context.Context, filter *repositories.CredentialFilter) (*repositories.Credential, error) {
-	result, err := r.FirstOrNil(nil, filter)
+	result, err := r.FirstOrNil(context.TODO(), filter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repositories/memory/credentials.go
+++ b/internal/repositories/memory/credentials.go
@@ -1,0 +1,122 @@
+package memory
+
+import (
+	"github.com/The127/Keyline/internal/change"
+	"github.com/The127/Keyline/internal/repositories"
+	"github.com/The127/Keyline/utils"
+	"context"
+	"encoding/json"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+type CredentialRepository struct {
+	store         map[uuid.UUID]*repositories.Credential
+	mu            *sync.RWMutex
+	changeTracker *change.Tracker
+	entityType    int
+}
+
+func NewCredentialRepository(store map[uuid.UUID]*repositories.Credential, mu *sync.RWMutex, changeTracker *change.Tracker, entityType int) *CredentialRepository {
+	return &CredentialRepository{
+		store:         store,
+		mu:            mu,
+		changeTracker: changeTracker,
+		entityType:    entityType,
+	}
+}
+
+func (r *CredentialRepository) matches(c *repositories.Credential, filter *repositories.CredentialFilter) bool {
+	if filter.HasId() && c.Id() != filter.GetId() {
+		return false
+	}
+	if filter.HasUserId() && c.UserId() != filter.GetUserId() {
+		return false
+	}
+	if filter.HasType() && c.Type() != filter.GetType() {
+		return false
+	}
+	if filter.HasDetailKid() || filter.HasDetailPublicKey() || filter.HasDetailsId() {
+		// marshal details to JSON to do field-level matching
+		detailJson, err := json.Marshal(c.Details())
+		if err != nil {
+			return false
+		}
+		var detailMap map[string]any
+		if err := json.Unmarshal(detailJson, &detailMap); err != nil {
+			return false
+		}
+
+		if filter.HasDetailKid() {
+			kid, _ := detailMap["kid"].(string)
+			if kid != filter.GetDetailKid() {
+				return false
+			}
+		}
+		if filter.HasDetailPublicKey() {
+			pk, _ := detailMap["publicKey"].(string)
+			if pk != filter.GetDetailPublicKey() {
+				return false
+			}
+		}
+		if filter.HasDetailsId() {
+			id, _ := detailMap["credentialId"].(string)
+			if id != filter.GetDetailsId() {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func (r *CredentialRepository) filtered(filter *repositories.CredentialFilter) []*repositories.Credential {
+	var result []*repositories.Credential
+	for _, c := range r.store {
+		if r.matches(c, filter) {
+			result = append(result, c)
+		}
+	}
+	return result
+}
+
+func (r *CredentialRepository) FirstOrErr(_ context.Context, filter *repositories.CredentialFilter) (*repositories.Credential, error) {
+	result, err := r.FirstOrNil(nil, filter)
+	if err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return nil, utils.ErrCredentialNotFound
+	}
+	return result, nil
+}
+
+func (r *CredentialRepository) FirstOrNil(_ context.Context, filter *repositories.CredentialFilter) (*repositories.Credential, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	items := r.filtered(filter)
+	if len(items) == 0 {
+		return nil, nil
+	}
+	return items[0], nil
+}
+
+func (r *CredentialRepository) List(_ context.Context, filter *repositories.CredentialFilter) ([]*repositories.Credential, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	return r.filtered(filter), nil
+}
+
+func (r *CredentialRepository) Insert(credential *repositories.Credential) {
+	r.changeTracker.Add(change.NewEntry(change.Added, r.entityType, credential))
+}
+
+func (r *CredentialRepository) Update(credential *repositories.Credential) {
+	r.changeTracker.Add(change.NewEntry(change.Updated, r.entityType, credential))
+}
+
+func (r *CredentialRepository) Delete(id uuid.UUID) {
+	r.changeTracker.Add(change.NewEntry(change.Deleted, r.entityType, id))
+}

--- a/internal/repositories/memory/credentials.go
+++ b/internal/repositories/memory/credentials.go
@@ -80,8 +80,8 @@ func (r *CredentialRepository) filtered(filter *repositories.CredentialFilter) [
 	return result
 }
 
-func (r *CredentialRepository) FirstOrErr(_ context.Context, filter *repositories.CredentialFilter) (*repositories.Credential, error) {
-	result, err := r.FirstOrNil(context.TODO(), filter)
+func (r *CredentialRepository) FirstOrErr(ctx context.Context, filter *repositories.CredentialFilter) (*repositories.Credential, error) {
+	result, err := r.FirstOrNil(ctx, filter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repositories/memory/files.go
+++ b/internal/repositories/memory/files.go
@@ -1,0 +1,61 @@
+package memory
+
+import (
+	"github.com/The127/Keyline/internal/change"
+	"github.com/The127/Keyline/internal/repositories"
+	"github.com/The127/Keyline/utils"
+	"context"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+type FileRepository struct {
+	store         map[uuid.UUID]*repositories.File
+	mu            *sync.RWMutex
+	changeTracker *change.Tracker
+	entityType    int
+}
+
+func NewFileRepository(store map[uuid.UUID]*repositories.File, mu *sync.RWMutex, changeTracker *change.Tracker, entityType int) *FileRepository {
+	return &FileRepository{
+		store:         store,
+		mu:            mu,
+		changeTracker: changeTracker,
+		entityType:    entityType,
+	}
+}
+
+func (r *FileRepository) matches(f *repositories.File, filter *repositories.FileFilter) bool {
+	if filter.HasId() && f.Id() != filter.GetId() {
+		return false
+	}
+	return true
+}
+
+func (r *FileRepository) FirstOrErr(_ context.Context, filter *repositories.FileFilter) (*repositories.File, error) {
+	result, err := r.FirstOrNil(nil, filter)
+	if err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return nil, utils.ErrFileNotFoud
+	}
+	return result, nil
+}
+
+func (r *FileRepository) FirstOrNil(_ context.Context, filter *repositories.FileFilter) (*repositories.File, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	for _, f := range r.store {
+		if r.matches(f, filter) {
+			return f, nil
+		}
+	}
+	return nil, nil
+}
+
+func (r *FileRepository) Insert(file *repositories.File) {
+	r.changeTracker.Add(change.NewEntry(change.Added, r.entityType, file))
+}

--- a/internal/repositories/memory/files.go
+++ b/internal/repositories/memory/files.go
@@ -33,8 +33,8 @@ func (r *FileRepository) matches(f *repositories.File, filter *repositories.File
 	return true
 }
 
-func (r *FileRepository) FirstOrErr(_ context.Context, filter *repositories.FileFilter) (*repositories.File, error) {
-	result, err := r.FirstOrNil(context.TODO(), filter)
+func (r *FileRepository) FirstOrErr(ctx context.Context, filter *repositories.FileFilter) (*repositories.File, error) {
+	result, err := r.FirstOrNil(ctx, filter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repositories/memory/files.go
+++ b/internal/repositories/memory/files.go
@@ -34,7 +34,7 @@ func (r *FileRepository) matches(f *repositories.File, filter *repositories.File
 }
 
 func (r *FileRepository) FirstOrErr(_ context.Context, filter *repositories.FileFilter) (*repositories.File, error) {
-	result, err := r.FirstOrNil(nil, filter)
+	result, err := r.FirstOrNil(context.TODO(), filter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repositories/memory/grouproles.go
+++ b/internal/repositories/memory/grouproles.go
@@ -1,0 +1,27 @@
+package memory
+
+import (
+	"github.com/The127/Keyline/internal/change"
+	"github.com/The127/Keyline/internal/repositories"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+// GroupRoleRepository implements repositories.GroupRoleRepository.
+// The interface has no methods — it is a marker interface.
+type GroupRoleRepository struct {
+	store         map[uuid.UUID]*repositories.GroupRole
+	mu            *sync.RWMutex
+	changeTracker *change.Tracker
+	entityType    int
+}
+
+func NewGroupRoleRepository(store map[uuid.UUID]*repositories.GroupRole, mu *sync.RWMutex, changeTracker *change.Tracker, entityType int) *GroupRoleRepository {
+	return &GroupRoleRepository{
+		store:         store,
+		mu:            mu,
+		changeTracker: changeTracker,
+		entityType:    entityType,
+	}
+}

--- a/internal/repositories/memory/groups.go
+++ b/internal/repositories/memory/groups.go
@@ -55,8 +55,8 @@ func (r *GroupRepository) filtered(filter *repositories.GroupFilter) []*reposito
 	return result
 }
 
-func (r *GroupRepository) FirstOrErr(_ context.Context, filter *repositories.GroupFilter) (*repositories.Group, error) {
-	result, err := r.FirstOrNil(context.TODO(), filter)
+func (r *GroupRepository) FirstOrErr(ctx context.Context, filter *repositories.GroupFilter) (*repositories.Group, error) {
+	result, err := r.FirstOrNil(ctx, filter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repositories/memory/groups.go
+++ b/internal/repositories/memory/groups.go
@@ -1,0 +1,102 @@
+package memory
+
+import (
+	"github.com/The127/Keyline/internal/change"
+	"github.com/The127/Keyline/internal/repositories"
+	"github.com/The127/Keyline/utils"
+	"context"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+type GroupRepository struct {
+	store         map[uuid.UUID]*repositories.Group
+	mu            *sync.RWMutex
+	changeTracker *change.Tracker
+	entityType    int
+}
+
+func NewGroupRepository(store map[uuid.UUID]*repositories.Group, mu *sync.RWMutex, changeTracker *change.Tracker, entityType int) *GroupRepository {
+	return &GroupRepository{
+		store:         store,
+		mu:            mu,
+		changeTracker: changeTracker,
+		entityType:    entityType,
+	}
+}
+
+func (r *GroupRepository) matches(g *repositories.Group, filter *repositories.GroupFilter) bool {
+	if filter.HasId() && g.Id() != filter.GetId() {
+		return false
+	}
+	if filter.HasName() && g.Name() != filter.GetName() {
+		return false
+	}
+	if filter.HasVirtualServerId() && g.VirtualServerId() != filter.GetVirtualServerId() {
+		return false
+	}
+	if filter.HasSearch() {
+		sf := filter.GetSearch()
+		if !matchesSearch(g.Name(), sf) && !matchesSearch(g.Description(), sf) {
+			return false
+		}
+	}
+	return true
+}
+
+func (r *GroupRepository) filtered(filter *repositories.GroupFilter) []*repositories.Group {
+	var result []*repositories.Group
+	for _, g := range r.store {
+		if r.matches(g, filter) {
+			result = append(result, g)
+		}
+	}
+	return result
+}
+
+func (r *GroupRepository) FirstOrErr(_ context.Context, filter *repositories.GroupFilter) (*repositories.Group, error) {
+	result, err := r.FirstOrNil(nil, filter)
+	if err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return nil, utils.ErrGroupNotFound
+	}
+	return result, nil
+}
+
+func (r *GroupRepository) FirstOrNil(_ context.Context, filter *repositories.GroupFilter) (*repositories.Group, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	items := r.filtered(filter)
+	if len(items) == 0 {
+		return nil, nil
+	}
+	return items[0], nil
+}
+
+func (r *GroupRepository) List(_ context.Context, filter *repositories.GroupFilter) ([]*repositories.Group, int, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	items := r.filtered(filter)
+	total := len(items)
+	if filter.HasPagination() {
+		items = paginateSlice(items, filter.GetPagingInfo())
+	}
+	return items, total, nil
+}
+
+func (r *GroupRepository) Insert(group *repositories.Group) {
+	r.changeTracker.Add(change.NewEntry(change.Added, r.entityType, group))
+}
+
+func (r *GroupRepository) Update(group *repositories.Group) {
+	r.changeTracker.Add(change.NewEntry(change.Updated, r.entityType, group))
+}
+
+func (r *GroupRepository) Delete(id uuid.UUID) {
+	r.changeTracker.Add(change.NewEntry(change.Deleted, r.entityType, id))
+}

--- a/internal/repositories/memory/groups.go
+++ b/internal/repositories/memory/groups.go
@@ -56,7 +56,7 @@ func (r *GroupRepository) filtered(filter *repositories.GroupFilter) []*reposito
 }
 
 func (r *GroupRepository) FirstOrErr(_ context.Context, filter *repositories.GroupFilter) (*repositories.Group, error) {
-	result, err := r.FirstOrNil(nil, filter)
+	result, err := r.FirstOrNil(context.TODO(), filter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repositories/memory/outboxmessages.go
+++ b/internal/repositories/memory/outboxmessages.go
@@ -29,7 +29,7 @@ func (r *OutboxMessageRepository) List(_ context.Context, filter *repositories.O
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	var result []*repositories.OutboxMessage
+	result := make([]*repositories.OutboxMessage, 0, len(r.store))
 	for _, m := range r.store {
 		if filter.HasId() && m.Id() != filter.GetId() {
 			continue

--- a/internal/repositories/memory/outboxmessages.go
+++ b/internal/repositories/memory/outboxmessages.go
@@ -1,0 +1,48 @@
+package memory
+
+import (
+	"github.com/The127/Keyline/internal/change"
+	"github.com/The127/Keyline/internal/repositories"
+	"context"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+type OutboxMessageRepository struct {
+	store         map[uuid.UUID]*repositories.OutboxMessage
+	mu            *sync.RWMutex
+	changeTracker *change.Tracker
+	entityType    int
+}
+
+func NewOutboxMessageRepository(store map[uuid.UUID]*repositories.OutboxMessage, mu *sync.RWMutex, changeTracker *change.Tracker, entityType int) *OutboxMessageRepository {
+	return &OutboxMessageRepository{
+		store:         store,
+		mu:            mu,
+		changeTracker: changeTracker,
+		entityType:    entityType,
+	}
+}
+
+func (r *OutboxMessageRepository) List(_ context.Context, filter *repositories.OutboxMessageFilter) ([]*repositories.OutboxMessage, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var result []*repositories.OutboxMessage
+	for _, m := range r.store {
+		if filter.HasId() && m.Id() != filter.GetId() {
+			continue
+		}
+		result = append(result, m)
+	}
+	return result, nil
+}
+
+func (r *OutboxMessageRepository) Insert(outboxMessage *repositories.OutboxMessage) {
+	r.changeTracker.Add(change.NewEntry(change.Added, r.entityType, outboxMessage))
+}
+
+func (r *OutboxMessageRepository) Delete(id uuid.UUID) {
+	r.changeTracker.Add(change.NewEntry(change.Deleted, r.entityType, id))
+}

--- a/internal/repositories/memory/passwordrules.go
+++ b/internal/repositories/memory/passwordrules.go
@@ -46,8 +46,8 @@ func (r *PasswordRuleRepository) filtered(filter *repositories.PasswordRuleFilte
 	return result
 }
 
-func (r *PasswordRuleRepository) FirstOrErr(_ context.Context, filter *repositories.PasswordRuleFilter) (*repositories.PasswordRule, error) {
-	result, err := r.FirstOrNil(context.TODO(), filter)
+func (r *PasswordRuleRepository) FirstOrErr(ctx context.Context, filter *repositories.PasswordRuleFilter) (*repositories.PasswordRule, error) {
+	result, err := r.FirstOrNil(ctx, filter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repositories/memory/passwordrules.go
+++ b/internal/repositories/memory/passwordrules.go
@@ -47,7 +47,7 @@ func (r *PasswordRuleRepository) filtered(filter *repositories.PasswordRuleFilte
 }
 
 func (r *PasswordRuleRepository) FirstOrErr(_ context.Context, filter *repositories.PasswordRuleFilter) (*repositories.PasswordRule, error) {
-	result, err := r.FirstOrNil(nil, filter)
+	result, err := r.FirstOrNil(context.TODO(), filter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repositories/memory/passwordrules.go
+++ b/internal/repositories/memory/passwordrules.go
@@ -1,0 +1,88 @@
+package memory
+
+import (
+	"github.com/The127/Keyline/internal/change"
+	"github.com/The127/Keyline/internal/repositories"
+	"github.com/The127/Keyline/utils"
+	"context"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+type PasswordRuleRepository struct {
+	store         map[uuid.UUID]*repositories.PasswordRule
+	mu            *sync.RWMutex
+	changeTracker *change.Tracker
+	entityType    int
+}
+
+func NewPasswordRuleRepository(store map[uuid.UUID]*repositories.PasswordRule, mu *sync.RWMutex, changeTracker *change.Tracker, entityType int) *PasswordRuleRepository {
+	return &PasswordRuleRepository{
+		store:         store,
+		mu:            mu,
+		changeTracker: changeTracker,
+		entityType:    entityType,
+	}
+}
+
+func (r *PasswordRuleRepository) matches(p *repositories.PasswordRule, filter *repositories.PasswordRuleFilter) bool {
+	if filter.HasVirtualServerId() && p.VirtualServerId() != filter.GetVirtualServerId() {
+		return false
+	}
+	if filter.HasType() && p.Type() != filter.GetType() {
+		return false
+	}
+	return true
+}
+
+func (r *PasswordRuleRepository) filtered(filter *repositories.PasswordRuleFilter) []*repositories.PasswordRule {
+	var result []*repositories.PasswordRule
+	for _, p := range r.store {
+		if r.matches(p, filter) {
+			result = append(result, p)
+		}
+	}
+	return result
+}
+
+func (r *PasswordRuleRepository) FirstOrErr(_ context.Context, filter *repositories.PasswordRuleFilter) (*repositories.PasswordRule, error) {
+	result, err := r.FirstOrNil(nil, filter)
+	if err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return nil, utils.ErrPasswordRuleNotFound
+	}
+	return result, nil
+}
+
+func (r *PasswordRuleRepository) FirstOrNil(_ context.Context, filter *repositories.PasswordRuleFilter) (*repositories.PasswordRule, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	items := r.filtered(filter)
+	if len(items) == 0 {
+		return nil, nil
+	}
+	return items[0], nil
+}
+
+func (r *PasswordRuleRepository) List(_ context.Context, filter *repositories.PasswordRuleFilter) ([]*repositories.PasswordRule, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	return r.filtered(filter), nil
+}
+
+func (r *PasswordRuleRepository) Insert(passwordRule *repositories.PasswordRule) {
+	r.changeTracker.Add(change.NewEntry(change.Added, r.entityType, passwordRule))
+}
+
+func (r *PasswordRuleRepository) Update(passwordRule *repositories.PasswordRule) {
+	r.changeTracker.Add(change.NewEntry(change.Updated, r.entityType, passwordRule))
+}
+
+func (r *PasswordRuleRepository) Delete(id uuid.UUID) {
+	r.changeTracker.Add(change.NewEntry(change.Deleted, r.entityType, id))
+}

--- a/internal/repositories/memory/projects.go
+++ b/internal/repositories/memory/projects.go
@@ -55,8 +55,8 @@ func (r *ProjectRepository) filtered(filter *repositories.ProjectFilter) []*repo
 	return result
 }
 
-func (r *ProjectRepository) FirstOrErr(_ context.Context, filter *repositories.ProjectFilter) (*repositories.Project, error) {
-	result, err := r.FirstOrNil(context.TODO(), filter)
+func (r *ProjectRepository) FirstOrErr(ctx context.Context, filter *repositories.ProjectFilter) (*repositories.Project, error) {
+	result, err := r.FirstOrNil(ctx, filter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repositories/memory/projects.go
+++ b/internal/repositories/memory/projects.go
@@ -56,7 +56,7 @@ func (r *ProjectRepository) filtered(filter *repositories.ProjectFilter) []*repo
 }
 
 func (r *ProjectRepository) FirstOrErr(_ context.Context, filter *repositories.ProjectFilter) (*repositories.Project, error) {
-	result, err := r.FirstOrNil(nil, filter)
+	result, err := r.FirstOrNil(context.TODO(), filter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repositories/memory/projects.go
+++ b/internal/repositories/memory/projects.go
@@ -1,0 +1,102 @@
+package memory
+
+import (
+	"github.com/The127/Keyline/internal/change"
+	"github.com/The127/Keyline/internal/repositories"
+	"github.com/The127/Keyline/utils"
+	"context"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+type ProjectRepository struct {
+	store         map[uuid.UUID]*repositories.Project
+	mu            *sync.RWMutex
+	changeTracker *change.Tracker
+	entityType    int
+}
+
+func NewProjectRepository(store map[uuid.UUID]*repositories.Project, mu *sync.RWMutex, changeTracker *change.Tracker, entityType int) *ProjectRepository {
+	return &ProjectRepository{
+		store:         store,
+		mu:            mu,
+		changeTracker: changeTracker,
+		entityType:    entityType,
+	}
+}
+
+func (r *ProjectRepository) matches(p *repositories.Project, filter *repositories.ProjectFilter) bool {
+	if filter.HasId() && p.Id() != filter.GetId() {
+		return false
+	}
+	if filter.HasVirtualServerId() && p.VirtualServerId() != filter.GetVirtualServerId() {
+		return false
+	}
+	if filter.HasSlug() && p.Slug() != filter.GetSlug() {
+		return false
+	}
+	if filter.HasSearch() {
+		sf := filter.GetSearch()
+		if !matchesSearch(p.Name(), sf) && !matchesSearch(p.Slug(), sf) && !matchesSearch(p.Description(), sf) {
+			return false
+		}
+	}
+	return true
+}
+
+func (r *ProjectRepository) filtered(filter *repositories.ProjectFilter) []*repositories.Project {
+	var result []*repositories.Project
+	for _, p := range r.store {
+		if r.matches(p, filter) {
+			result = append(result, p)
+		}
+	}
+	return result
+}
+
+func (r *ProjectRepository) FirstOrErr(_ context.Context, filter *repositories.ProjectFilter) (*repositories.Project, error) {
+	result, err := r.FirstOrNil(nil, filter)
+	if err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return nil, utils.ErrProjectNotFound
+	}
+	return result, nil
+}
+
+func (r *ProjectRepository) FirstOrNil(_ context.Context, filter *repositories.ProjectFilter) (*repositories.Project, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	items := r.filtered(filter)
+	if len(items) == 0 {
+		return nil, nil
+	}
+	return items[0], nil
+}
+
+func (r *ProjectRepository) List(_ context.Context, filter *repositories.ProjectFilter) ([]*repositories.Project, int, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	items := r.filtered(filter)
+	total := len(items)
+	if filter.HasPagination() {
+		items = paginateSlice(items, filter.GetPagingInfo())
+	}
+	return items, total, nil
+}
+
+func (r *ProjectRepository) Insert(project *repositories.Project) {
+	r.changeTracker.Add(change.NewEntry(change.Added, r.entityType, project))
+}
+
+func (r *ProjectRepository) Update(project *repositories.Project) {
+	r.changeTracker.Add(change.NewEntry(change.Updated, r.entityType, project))
+}
+
+func (r *ProjectRepository) Delete(id uuid.UUID) {
+	r.changeTracker.Add(change.NewEntry(change.Deleted, r.entityType, id))
+}

--- a/internal/repositories/memory/resourceservers.go
+++ b/internal/repositories/memory/resourceservers.go
@@ -59,7 +59,7 @@ func (r *ResourceServerRepository) filtered(filter *repositories.ResourceServerF
 }
 
 func (r *ResourceServerRepository) FirstOrErr(_ context.Context, filter *repositories.ResourceServerFilter) (*repositories.ResourceServer, error) {
-	result, err := r.FirstOrNil(nil, filter)
+	result, err := r.FirstOrNil(context.TODO(), filter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repositories/memory/resourceservers.go
+++ b/internal/repositories/memory/resourceservers.go
@@ -1,0 +1,105 @@
+package memory
+
+import (
+	"github.com/The127/Keyline/internal/change"
+	"github.com/The127/Keyline/internal/repositories"
+	"github.com/The127/Keyline/utils"
+	"context"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+type ResourceServerRepository struct {
+	store         map[uuid.UUID]*repositories.ResourceServer
+	mu            *sync.RWMutex
+	changeTracker *change.Tracker
+	entityType    int
+}
+
+func NewResourceServerRepository(store map[uuid.UUID]*repositories.ResourceServer, mu *sync.RWMutex, changeTracker *change.Tracker, entityType int) *ResourceServerRepository {
+	return &ResourceServerRepository{
+		store:         store,
+		mu:            mu,
+		changeTracker: changeTracker,
+		entityType:    entityType,
+	}
+}
+
+func (r *ResourceServerRepository) matches(rs *repositories.ResourceServer, filter *repositories.ResourceServerFilter) bool {
+	if filter.HasId() && rs.Id() != filter.GetId() {
+		return false
+	}
+	if filter.HasSlug() && rs.Slug() != filter.GetSlug() {
+		return false
+	}
+	if filter.HasVirtualServerId() && rs.VirtualServerId() != filter.GetVirtualServerId() {
+		return false
+	}
+	if filter.HasProjectId() && rs.ProjectId() != filter.GetProjectId() {
+		return false
+	}
+	if filter.HasSearch() {
+		sf := filter.GetSearch()
+		if !matchesSearch(rs.Name(), sf) && !matchesSearch(rs.Slug(), sf) {
+			return false
+		}
+	}
+	return true
+}
+
+func (r *ResourceServerRepository) filtered(filter *repositories.ResourceServerFilter) []*repositories.ResourceServer {
+	var result []*repositories.ResourceServer
+	for _, rs := range r.store {
+		if r.matches(rs, filter) {
+			result = append(result, rs)
+		}
+	}
+	return result
+}
+
+func (r *ResourceServerRepository) FirstOrErr(_ context.Context, filter *repositories.ResourceServerFilter) (*repositories.ResourceServer, error) {
+	result, err := r.FirstOrNil(nil, filter)
+	if err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return nil, utils.ErrResourceServerNotFound
+	}
+	return result, nil
+}
+
+func (r *ResourceServerRepository) FirstOrNil(_ context.Context, filter *repositories.ResourceServerFilter) (*repositories.ResourceServer, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	items := r.filtered(filter)
+	if len(items) == 0 {
+		return nil, nil
+	}
+	return items[0], nil
+}
+
+func (r *ResourceServerRepository) List(_ context.Context, filter *repositories.ResourceServerFilter) ([]*repositories.ResourceServer, int, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	items := r.filtered(filter)
+	total := len(items)
+	if filter.HasPagination() {
+		items = paginateSlice(items, filter.GetPagingInfo())
+	}
+	return items, total, nil
+}
+
+func (r *ResourceServerRepository) Insert(resourceServer *repositories.ResourceServer) {
+	r.changeTracker.Add(change.NewEntry(change.Added, r.entityType, resourceServer))
+}
+
+func (r *ResourceServerRepository) Update(resourceServer *repositories.ResourceServer) {
+	r.changeTracker.Add(change.NewEntry(change.Updated, r.entityType, resourceServer))
+}
+
+func (r *ResourceServerRepository) Delete(id uuid.UUID) {
+	r.changeTracker.Add(change.NewEntry(change.Deleted, r.entityType, id))
+}

--- a/internal/repositories/memory/resourceservers.go
+++ b/internal/repositories/memory/resourceservers.go
@@ -58,8 +58,8 @@ func (r *ResourceServerRepository) filtered(filter *repositories.ResourceServerF
 	return result
 }
 
-func (r *ResourceServerRepository) FirstOrErr(_ context.Context, filter *repositories.ResourceServerFilter) (*repositories.ResourceServer, error) {
-	result, err := r.FirstOrNil(context.TODO(), filter)
+func (r *ResourceServerRepository) FirstOrErr(ctx context.Context, filter *repositories.ResourceServerFilter) (*repositories.ResourceServer, error) {
+	result, err := r.FirstOrNil(ctx, filter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repositories/memory/resourceserverscopes.go
+++ b/internal/repositories/memory/resourceserverscopes.go
@@ -1,0 +1,105 @@
+package memory
+
+import (
+	"github.com/The127/Keyline/internal/change"
+	"github.com/The127/Keyline/internal/repositories"
+	"github.com/The127/Keyline/utils"
+	"context"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+type ResourceServerScopeRepository struct {
+	store         map[uuid.UUID]*repositories.ResourceServerScope
+	mu            *sync.RWMutex
+	changeTracker *change.Tracker
+	entityType    int
+}
+
+func NewResourceServerScopeRepository(store map[uuid.UUID]*repositories.ResourceServerScope, mu *sync.RWMutex, changeTracker *change.Tracker, entityType int) *ResourceServerScopeRepository {
+	return &ResourceServerScopeRepository{
+		store:         store,
+		mu:            mu,
+		changeTracker: changeTracker,
+		entityType:    entityType,
+	}
+}
+
+func (r *ResourceServerScopeRepository) matches(s *repositories.ResourceServerScope, filter *repositories.ResourceServerScopeFilter) bool {
+	if filter.HasId() && s.Id() != filter.GetId() {
+		return false
+	}
+	if filter.HasVirtualServerId() && s.VirtualServerId() != filter.GetVirtualServerId() {
+		return false
+	}
+	if filter.HasProjectId() && s.ProjectId() != filter.GetProjectId() {
+		return false
+	}
+	if filter.HasResourceServerId() && s.ResourceServerId() != filter.GetResourceServerId() {
+		return false
+	}
+	if filter.HasSearch() {
+		sf := filter.GetSearch()
+		if !matchesSearch(s.Name(), sf) && !matchesSearch(s.Scope(), sf) {
+			return false
+		}
+	}
+	return true
+}
+
+func (r *ResourceServerScopeRepository) filtered(filter *repositories.ResourceServerScopeFilter) []*repositories.ResourceServerScope {
+	var result []*repositories.ResourceServerScope
+	for _, s := range r.store {
+		if r.matches(s, filter) {
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
+func (r *ResourceServerScopeRepository) FirstOrErr(_ context.Context, filter *repositories.ResourceServerScopeFilter) (*repositories.ResourceServerScope, error) {
+	result, err := r.FirstOrNil(nil, filter)
+	if err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return nil, utils.ErrResourceServerScopeNotFound
+	}
+	return result, nil
+}
+
+func (r *ResourceServerScopeRepository) FirstOrNil(_ context.Context, filter *repositories.ResourceServerScopeFilter) (*repositories.ResourceServerScope, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	items := r.filtered(filter)
+	if len(items) == 0 {
+		return nil, nil
+	}
+	return items[0], nil
+}
+
+func (r *ResourceServerScopeRepository) List(_ context.Context, filter *repositories.ResourceServerScopeFilter) ([]*repositories.ResourceServerScope, int, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	items := r.filtered(filter)
+	total := len(items)
+	if filter.HasPagination() {
+		items = paginateSlice(items, filter.GetPagingInfo())
+	}
+	return items, total, nil
+}
+
+func (r *ResourceServerScopeRepository) Insert(scope *repositories.ResourceServerScope) {
+	r.changeTracker.Add(change.NewEntry(change.Added, r.entityType, scope))
+}
+
+func (r *ResourceServerScopeRepository) Update(scope *repositories.ResourceServerScope) {
+	r.changeTracker.Add(change.NewEntry(change.Updated, r.entityType, scope))
+}
+
+func (r *ResourceServerScopeRepository) Delete(id uuid.UUID) {
+	r.changeTracker.Add(change.NewEntry(change.Deleted, r.entityType, id))
+}

--- a/internal/repositories/memory/resourceserverscopes.go
+++ b/internal/repositories/memory/resourceserverscopes.go
@@ -58,8 +58,8 @@ func (r *ResourceServerScopeRepository) filtered(filter *repositories.ResourceSe
 	return result
 }
 
-func (r *ResourceServerScopeRepository) FirstOrErr(_ context.Context, filter *repositories.ResourceServerScopeFilter) (*repositories.ResourceServerScope, error) {
-	result, err := r.FirstOrNil(context.TODO(), filter)
+func (r *ResourceServerScopeRepository) FirstOrErr(ctx context.Context, filter *repositories.ResourceServerScopeFilter) (*repositories.ResourceServerScope, error) {
+	result, err := r.FirstOrNil(ctx, filter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repositories/memory/resourceserverscopes.go
+++ b/internal/repositories/memory/resourceserverscopes.go
@@ -59,7 +59,7 @@ func (r *ResourceServerScopeRepository) filtered(filter *repositories.ResourceSe
 }
 
 func (r *ResourceServerScopeRepository) FirstOrErr(_ context.Context, filter *repositories.ResourceServerScopeFilter) (*repositories.ResourceServerScope, error) {
-	result, err := r.FirstOrNil(nil, filter)
+	result, err := r.FirstOrNil(context.TODO(), filter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repositories/memory/roles.go
+++ b/internal/repositories/memory/roles.go
@@ -1,0 +1,105 @@
+package memory
+
+import (
+	"github.com/The127/Keyline/internal/change"
+	"github.com/The127/Keyline/internal/repositories"
+	"github.com/The127/Keyline/utils"
+	"context"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+type RoleRepository struct {
+	store         map[uuid.UUID]*repositories.Role
+	mu            *sync.RWMutex
+	changeTracker *change.Tracker
+	entityType    int
+}
+
+func NewRoleRepository(store map[uuid.UUID]*repositories.Role, mu *sync.RWMutex, changeTracker *change.Tracker, entityType int) *RoleRepository {
+	return &RoleRepository{
+		store:         store,
+		mu:            mu,
+		changeTracker: changeTracker,
+		entityType:    entityType,
+	}
+}
+
+func (r *RoleRepository) matches(role *repositories.Role, filter *repositories.RoleFilter) bool {
+	if filter.HasId() && role.Id() != filter.GetId() {
+		return false
+	}
+	if filter.HasName() && role.Name() != filter.GetName() {
+		return false
+	}
+	if filter.HasVirtualServerId() && role.VirtualServerId() != filter.GetVirtualServerId() {
+		return false
+	}
+	if filter.HasProjectId() && role.ProjectId() != filter.GetProjectId() {
+		return false
+	}
+	if filter.HasSearch() {
+		sf := filter.GetSearch()
+		if !matchesSearch(role.Name(), sf) && !matchesSearch(role.Description(), sf) {
+			return false
+		}
+	}
+	return true
+}
+
+func (r *RoleRepository) filtered(filter *repositories.RoleFilter) []*repositories.Role {
+	var result []*repositories.Role
+	for _, role := range r.store {
+		if r.matches(role, filter) {
+			result = append(result, role)
+		}
+	}
+	return result
+}
+
+func (r *RoleRepository) FirstOrErr(_ context.Context, filter *repositories.RoleFilter) (*repositories.Role, error) {
+	result, err := r.FirstOrNil(nil, filter)
+	if err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return nil, utils.ErrRoleNotFound
+	}
+	return result, nil
+}
+
+func (r *RoleRepository) FirstOrNil(_ context.Context, filter *repositories.RoleFilter) (*repositories.Role, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	items := r.filtered(filter)
+	if len(items) == 0 {
+		return nil, nil
+	}
+	return items[0], nil
+}
+
+func (r *RoleRepository) List(_ context.Context, filter *repositories.RoleFilter) ([]*repositories.Role, int, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	items := r.filtered(filter)
+	total := len(items)
+	if filter.HasPagination() {
+		items = paginateSlice(items, filter.GetPagingInfo())
+	}
+	return items, total, nil
+}
+
+func (r *RoleRepository) Insert(role *repositories.Role) {
+	r.changeTracker.Add(change.NewEntry(change.Added, r.entityType, role))
+}
+
+func (r *RoleRepository) Update(role *repositories.Role) {
+	r.changeTracker.Add(change.NewEntry(change.Updated, r.entityType, role))
+}
+
+func (r *RoleRepository) Delete(id uuid.UUID) {
+	r.changeTracker.Add(change.NewEntry(change.Deleted, r.entityType, id))
+}

--- a/internal/repositories/memory/roles.go
+++ b/internal/repositories/memory/roles.go
@@ -59,7 +59,7 @@ func (r *RoleRepository) filtered(filter *repositories.RoleFilter) []*repositori
 }
 
 func (r *RoleRepository) FirstOrErr(_ context.Context, filter *repositories.RoleFilter) (*repositories.Role, error) {
-	result, err := r.FirstOrNil(nil, filter)
+	result, err := r.FirstOrNil(context.TODO(), filter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repositories/memory/roles.go
+++ b/internal/repositories/memory/roles.go
@@ -58,8 +58,8 @@ func (r *RoleRepository) filtered(filter *repositories.RoleFilter) []*repositori
 	return result
 }
 
-func (r *RoleRepository) FirstOrErr(_ context.Context, filter *repositories.RoleFilter) (*repositories.Role, error) {
-	result, err := r.FirstOrNil(context.TODO(), filter)
+func (r *RoleRepository) FirstOrErr(ctx context.Context, filter *repositories.RoleFilter) (*repositories.Role, error) {
+	result, err := r.FirstOrNil(ctx, filter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repositories/memory/search.go
+++ b/internal/repositories/memory/search.go
@@ -1,0 +1,47 @@
+package memory
+
+import (
+	"github.com/The127/Keyline/internal/repositories"
+	"strings"
+)
+
+func matchesSearch(value string, sf repositories.SearchFilter) bool {
+	term := sf.Term()
+	switch {
+	case strings.HasPrefix(term, "%") && strings.HasSuffix(term, "%"):
+		// contains
+		inner := term[1 : len(term)-1]
+		return strings.Contains(strings.ToLower(value), strings.ToLower(inner))
+	case strings.HasSuffix(term, "%"):
+		// starts with
+		prefix := term[:len(term)-1]
+		return strings.HasPrefix(strings.ToLower(value), strings.ToLower(prefix))
+	case strings.HasPrefix(term, "%"):
+		// ends with
+		suffix := term[1:]
+		return strings.HasSuffix(strings.ToLower(value), strings.ToLower(suffix))
+	default:
+		// exact
+		return strings.EqualFold(value, term)
+	}
+}
+
+func paginateSlice[T any](items []T, pi repositories.PagingInfo) []T {
+	if pi.IsZero() {
+		return items
+	}
+	page := pi.Page()
+	size := pi.Size()
+	if page < 1 {
+		page = 1
+	}
+	offset := (page - 1) * size
+	if offset >= len(items) {
+		return []T{}
+	}
+	end := offset + size
+	if end > len(items) {
+		end = len(items)
+	}
+	return items[offset:end]
+}

--- a/internal/repositories/memory/sessions.go
+++ b/internal/repositories/memory/sessions.go
@@ -39,8 +39,8 @@ func (r *SessionRepository) matches(s *repositories.Session, filter *repositorie
 	return true
 }
 
-func (r *SessionRepository) FirstOrErr(_ context.Context, filter *repositories.SessionFilter) (*repositories.Session, error) {
-	result, err := r.FirstOrNil(context.TODO(), filter)
+func (r *SessionRepository) FirstOrErr(ctx context.Context, filter *repositories.SessionFilter) (*repositories.Session, error) {
+	result, err := r.FirstOrNil(ctx, filter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repositories/memory/sessions.go
+++ b/internal/repositories/memory/sessions.go
@@ -1,0 +1,71 @@
+package memory
+
+import (
+	"github.com/The127/Keyline/internal/change"
+	"github.com/The127/Keyline/internal/repositories"
+	"github.com/The127/Keyline/utils"
+	"context"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+type SessionRepository struct {
+	store         map[uuid.UUID]*repositories.Session
+	mu            *sync.RWMutex
+	changeTracker *change.Tracker
+	entityType    int
+}
+
+func NewSessionRepository(store map[uuid.UUID]*repositories.Session, mu *sync.RWMutex, changeTracker *change.Tracker, entityType int) *SessionRepository {
+	return &SessionRepository{
+		store:         store,
+		mu:            mu,
+		changeTracker: changeTracker,
+		entityType:    entityType,
+	}
+}
+
+func (r *SessionRepository) matches(s *repositories.Session, filter *repositories.SessionFilter) bool {
+	if filter.HasId() && s.Id() != filter.GetId() {
+		return false
+	}
+	if filter.HasVirtualServerId() && s.VirtualServerId() != filter.GetVirtualServerId() {
+		return false
+	}
+	if filter.HasUserId() && s.UserId() != filter.GetUserId() {
+		return false
+	}
+	return true
+}
+
+func (r *SessionRepository) FirstOrErr(_ context.Context, filter *repositories.SessionFilter) (*repositories.Session, error) {
+	result, err := r.FirstOrNil(nil, filter)
+	if err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return nil, utils.ErrSessionNotFound
+	}
+	return result, nil
+}
+
+func (r *SessionRepository) FirstOrNil(_ context.Context, filter *repositories.SessionFilter) (*repositories.Session, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	for _, s := range r.store {
+		if r.matches(s, filter) {
+			return s, nil
+		}
+	}
+	return nil, nil
+}
+
+func (r *SessionRepository) Insert(session *repositories.Session) {
+	r.changeTracker.Add(change.NewEntry(change.Added, r.entityType, session))
+}
+
+func (r *SessionRepository) Delete(id uuid.UUID) {
+	r.changeTracker.Add(change.NewEntry(change.Deleted, r.entityType, id))
+}

--- a/internal/repositories/memory/sessions.go
+++ b/internal/repositories/memory/sessions.go
@@ -40,7 +40,7 @@ func (r *SessionRepository) matches(s *repositories.Session, filter *repositorie
 }
 
 func (r *SessionRepository) FirstOrErr(_ context.Context, filter *repositories.SessionFilter) (*repositories.Session, error) {
-	result, err := r.FirstOrNil(nil, filter)
+	result, err := r.FirstOrNil(context.TODO(), filter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repositories/memory/templates.go
+++ b/internal/repositories/memory/templates.go
@@ -46,8 +46,8 @@ func (r *TemplateRepository) filtered(filter *repositories.TemplateFilter) []*re
 	return result
 }
 
-func (r *TemplateRepository) FirstOrErr(_ context.Context, filter *repositories.TemplateFilter) (*repositories.Template, error) {
-	result, err := r.FirstOrNil(context.TODO(), filter)
+func (r *TemplateRepository) FirstOrErr(ctx context.Context, filter *repositories.TemplateFilter) (*repositories.Template, error) {
+	result, err := r.FirstOrNil(ctx, filter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repositories/memory/templates.go
+++ b/internal/repositories/memory/templates.go
@@ -47,7 +47,7 @@ func (r *TemplateRepository) filtered(filter *repositories.TemplateFilter) []*re
 }
 
 func (r *TemplateRepository) FirstOrErr(_ context.Context, filter *repositories.TemplateFilter) (*repositories.Template, error) {
-	result, err := r.FirstOrNil(nil, filter)
+	result, err := r.FirstOrNil(context.TODO(), filter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repositories/memory/templates.go
+++ b/internal/repositories/memory/templates.go
@@ -1,0 +1,85 @@
+package memory
+
+import (
+	"github.com/The127/Keyline/internal/change"
+	"github.com/The127/Keyline/internal/repositories"
+	"github.com/The127/Keyline/utils"
+	"context"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+type TemplateRepository struct {
+	store         map[uuid.UUID]*repositories.Template
+	mu            *sync.RWMutex
+	changeTracker *change.Tracker
+	entityType    int
+}
+
+func NewTemplateRepository(store map[uuid.UUID]*repositories.Template, mu *sync.RWMutex, changeTracker *change.Tracker, entityType int) *TemplateRepository {
+	return &TemplateRepository{
+		store:         store,
+		mu:            mu,
+		changeTracker: changeTracker,
+		entityType:    entityType,
+	}
+}
+
+func (r *TemplateRepository) matches(t *repositories.Template, filter *repositories.TemplateFilter) bool {
+	if filter.HasVirtualServerId() && t.VirtualServerId() != filter.GetVirtualServerId() {
+		return false
+	}
+	if filter.HasTemplateType() && t.TemplateType() != filter.GetTemplateType() {
+		return false
+	}
+	return true
+}
+
+func (r *TemplateRepository) filtered(filter *repositories.TemplateFilter) []*repositories.Template {
+	var result []*repositories.Template
+	for _, t := range r.store {
+		if r.matches(t, filter) {
+			result = append(result, t)
+		}
+	}
+	return result
+}
+
+func (r *TemplateRepository) FirstOrErr(_ context.Context, filter *repositories.TemplateFilter) (*repositories.Template, error) {
+	result, err := r.FirstOrNil(nil, filter)
+	if err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return nil, utils.ErrTemplateNotFound
+	}
+	return result, nil
+}
+
+func (r *TemplateRepository) FirstOrNil(_ context.Context, filter *repositories.TemplateFilter) (*repositories.Template, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	items := r.filtered(filter)
+	if len(items) == 0 {
+		return nil, nil
+	}
+	return items[0], nil
+}
+
+func (r *TemplateRepository) List(_ context.Context, filter *repositories.TemplateFilter) ([]*repositories.Template, int, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	items := r.filtered(filter)
+	total := len(items)
+	if filter.HasPagination() {
+		items = paginateSlice(items, filter.GetPagingInfo())
+	}
+	return items, total, nil
+}
+
+func (r *TemplateRepository) Insert(template *repositories.Template) {
+	r.changeTracker.Add(change.NewEntry(change.Added, r.entityType, template))
+}

--- a/internal/repositories/memory/userroleassignments.go
+++ b/internal/repositories/memory/userroleassignments.go
@@ -1,0 +1,114 @@
+package memory
+
+import (
+	"github.com/The127/Keyline/internal/change"
+	"github.com/The127/Keyline/internal/repositories"
+	"context"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+type UserRoleAssignmentRepository struct {
+	store        map[uuid.UUID]*repositories.UserRoleAssignment
+	usersStore   map[uuid.UUID]*repositories.User
+	rolesStore   map[uuid.UUID]*repositories.Role
+	projectStore map[uuid.UUID]*repositories.Project
+	mu           *sync.RWMutex
+
+	changeTracker *change.Tracker
+	entityType    int
+}
+
+func NewUserRoleAssignmentRepository(
+	store map[uuid.UUID]*repositories.UserRoleAssignment,
+	usersStore map[uuid.UUID]*repositories.User,
+	rolesStore map[uuid.UUID]*repositories.Role,
+	projectStore map[uuid.UUID]*repositories.Project,
+	mu *sync.RWMutex,
+	changeTracker *change.Tracker,
+	entityType int,
+) *UserRoleAssignmentRepository {
+	return &UserRoleAssignmentRepository{
+		store:         store,
+		usersStore:    usersStore,
+		rolesStore:    rolesStore,
+		projectStore:  projectStore,
+		mu:            mu,
+		changeTracker: changeTracker,
+		entityType:    entityType,
+	}
+}
+
+func (r *UserRoleAssignmentRepository) matches(ura *repositories.UserRoleAssignment, filter *repositories.UserRoleAssignmentFilter) bool {
+	if filter.HasUserId() && ura.UserId() != filter.GetUserId() {
+		return false
+	}
+	if filter.HasRoleId() && ura.RoleId() != filter.GetRoleId() {
+		return false
+	}
+	if filter.HasGroupId() {
+		gid := filter.GetGroupId()
+		if ura.GroupId() == nil || *ura.GroupId() != gid {
+			return false
+		}
+	}
+	return true
+}
+
+func (r *UserRoleAssignmentRepository) enrich(ura *repositories.UserRoleAssignment, filter *repositories.UserRoleAssignmentFilter) *repositories.UserRoleAssignment {
+	var userInfo *repositories.UserRoleAssignmentUserInfo
+	var roleInfo *repositories.UserRoleAssignmentRoleInfo
+
+	if filter.GetIncludeUser() {
+		if u, ok := r.usersStore[ura.UserId()]; ok {
+			userInfo = &repositories.UserRoleAssignmentUserInfo{
+				Username:    u.Username(),
+				DisplayName: u.DisplayName(),
+			}
+		}
+	}
+
+	if filter.GetIncludeRole() {
+		if role, ok := r.rolesStore[ura.RoleId()]; ok {
+			projectSlug := ""
+			if p, ok := r.projectStore[role.ProjectId()]; ok {
+				projectSlug = p.Slug()
+			}
+			roleInfo = &repositories.UserRoleAssignmentRoleInfo{
+				ProjectSlug: projectSlug,
+				Name:        role.Name(),
+			}
+		}
+	}
+
+	if userInfo == nil && roleInfo == nil {
+		return ura
+	}
+
+	return repositories.NewUserRoleAssignmentFromDB(
+		ura.BaseModel,
+		ura.UserId(),
+		ura.RoleId(),
+		ura.GroupId(),
+		userInfo,
+		roleInfo,
+	)
+}
+
+func (r *UserRoleAssignmentRepository) List(_ context.Context, filter *repositories.UserRoleAssignmentFilter) ([]*repositories.UserRoleAssignment, int, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var items []*repositories.UserRoleAssignment
+	for _, ura := range r.store {
+		if r.matches(ura, filter) {
+			items = append(items, r.enrich(ura, filter))
+		}
+	}
+	return items, len(items), nil
+}
+
+func (r *UserRoleAssignmentRepository) Insert(userRoleAssignment *repositories.UserRoleAssignment) {
+	r.changeTracker.Add(change.NewEntry(change.Added, r.entityType, userRoleAssignment))
+}

--- a/internal/repositories/memory/users.go
+++ b/internal/repositories/memory/users.go
@@ -1,0 +1,101 @@
+package memory
+
+import (
+	"github.com/The127/Keyline/internal/change"
+	"github.com/The127/Keyline/internal/repositories"
+	"github.com/The127/Keyline/utils"
+	"context"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+type UserRepository struct {
+	store         map[uuid.UUID]*repositories.User
+	mu            *sync.RWMutex
+	changeTracker *change.Tracker
+	entityType    int
+}
+
+func NewUserRepository(store map[uuid.UUID]*repositories.User, mu *sync.RWMutex, changeTracker *change.Tracker, entityType int) *UserRepository {
+	return &UserRepository{
+		store:         store,
+		mu:            mu,
+		changeTracker: changeTracker,
+		entityType:    entityType,
+	}
+}
+
+func (r *UserRepository) matches(u *repositories.User, filter *repositories.UserFilter) bool {
+	if filter.HasId() && u.Id() != filter.GetId() {
+		return false
+	}
+	if filter.HasVirtualServerId() && u.VirtualServerId() != filter.GetVirtualServerId() {
+		return false
+	}
+	if filter.HasUsername() && u.Username() != filter.GetUsername() {
+		return false
+	}
+	if filter.HasServiceUser() && u.IsServiceUser() != filter.GetServiceUser() {
+		return false
+	}
+	if filter.HasSearch() {
+		sf := filter.GetSearch()
+		if !matchesSearch(u.Username(), sf) && !matchesSearch(u.DisplayName(), sf) {
+			return false
+		}
+	}
+	return true
+}
+
+func (r *UserRepository) filtered(filter *repositories.UserFilter) []*repositories.User {
+	var result []*repositories.User
+	for _, u := range r.store {
+		if r.matches(u, filter) {
+			result = append(result, u)
+		}
+	}
+	return result
+}
+
+func (r *UserRepository) FirstOrErr(_ context.Context, filter *repositories.UserFilter) (*repositories.User, error) {
+	result, err := r.FirstOrNil(nil, filter)
+	if err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return nil, utils.ErrUserNotFound
+	}
+	return result, nil
+}
+
+func (r *UserRepository) FirstOrNil(_ context.Context, filter *repositories.UserFilter) (*repositories.User, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	items := r.filtered(filter)
+	if len(items) == 0 {
+		return nil, nil
+	}
+	return items[0], nil
+}
+
+func (r *UserRepository) List(_ context.Context, filter *repositories.UserFilter) ([]*repositories.User, int, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	items := r.filtered(filter)
+	total := len(items)
+	if filter.HasPagination() {
+		items = paginateSlice(items, filter.GetPagingInfo())
+	}
+	return items, total, nil
+}
+
+func (r *UserRepository) Insert(user *repositories.User) {
+	r.changeTracker.Add(change.NewEntry(change.Added, r.entityType, user))
+}
+
+func (r *UserRepository) Update(user *repositories.User) {
+	r.changeTracker.Add(change.NewEntry(change.Updated, r.entityType, user))
+}

--- a/internal/repositories/memory/users.go
+++ b/internal/repositories/memory/users.go
@@ -58,8 +58,8 @@ func (r *UserRepository) filtered(filter *repositories.UserFilter) []*repositori
 	return result
 }
 
-func (r *UserRepository) FirstOrErr(_ context.Context, filter *repositories.UserFilter) (*repositories.User, error) {
-	result, err := r.FirstOrNil(context.TODO(), filter)
+func (r *UserRepository) FirstOrErr(ctx context.Context, filter *repositories.UserFilter) (*repositories.User, error) {
+	result, err := r.FirstOrNil(ctx, filter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repositories/memory/users.go
+++ b/internal/repositories/memory/users.go
@@ -59,7 +59,7 @@ func (r *UserRepository) filtered(filter *repositories.UserFilter) []*repositori
 }
 
 func (r *UserRepository) FirstOrErr(_ context.Context, filter *repositories.UserFilter) (*repositories.User, error) {
-	result, err := r.FirstOrNil(nil, filter)
+	result, err := r.FirstOrNil(context.TODO(), filter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repositories/memory/virtualservers.go
+++ b/internal/repositories/memory/virtualservers.go
@@ -46,8 +46,8 @@ func (r *VirtualServerRepository) filtered(filter *repositories.VirtualServerFil
 	return result
 }
 
-func (r *VirtualServerRepository) FirstOrErr(_ context.Context, filter *repositories.VirtualServerFilter) (*repositories.VirtualServer, error) {
-	result, err := r.FirstOrNil(context.TODO(), filter)
+func (r *VirtualServerRepository) FirstOrErr(ctx context.Context, filter *repositories.VirtualServerFilter) (*repositories.VirtualServer, error) {
+	result, err := r.FirstOrNil(ctx, filter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repositories/memory/virtualservers.go
+++ b/internal/repositories/memory/virtualservers.go
@@ -1,0 +1,85 @@
+package memory
+
+import (
+	"github.com/The127/Keyline/internal/change"
+	"github.com/The127/Keyline/internal/repositories"
+	"github.com/The127/Keyline/utils"
+	"context"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+type VirtualServerRepository struct {
+	store         map[uuid.UUID]*repositories.VirtualServer
+	mu            *sync.RWMutex
+	changeTracker *change.Tracker
+	entityType    int
+}
+
+func NewVirtualServerRepository(store map[uuid.UUID]*repositories.VirtualServer, mu *sync.RWMutex, changeTracker *change.Tracker, entityType int) *VirtualServerRepository {
+	return &VirtualServerRepository{
+		store:         store,
+		mu:            mu,
+		changeTracker: changeTracker,
+		entityType:    entityType,
+	}
+}
+
+func (r *VirtualServerRepository) matches(vs *repositories.VirtualServer, filter *repositories.VirtualServerFilter) bool {
+	if filter.HasName() && vs.Name() != filter.GetName() {
+		return false
+	}
+	if filter.HasId() && vs.Id() != filter.GetId() {
+		return false
+	}
+	return true
+}
+
+func (r *VirtualServerRepository) filtered(filter *repositories.VirtualServerFilter) []*repositories.VirtualServer {
+	var result []*repositories.VirtualServer
+	for _, vs := range r.store {
+		if r.matches(vs, filter) {
+			result = append(result, vs)
+		}
+	}
+	return result
+}
+
+func (r *VirtualServerRepository) FirstOrErr(_ context.Context, filter *repositories.VirtualServerFilter) (*repositories.VirtualServer, error) {
+	result, err := r.FirstOrNil(nil, filter)
+	if err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return nil, utils.ErrVirtualServerNotFound
+	}
+	return result, nil
+}
+
+func (r *VirtualServerRepository) FirstOrNil(_ context.Context, filter *repositories.VirtualServerFilter) (*repositories.VirtualServer, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	items := r.filtered(filter)
+	if len(items) == 0 {
+		return nil, nil
+	}
+	return items[0], nil
+}
+
+func (r *VirtualServerRepository) List(_ context.Context, filter *repositories.VirtualServerFilter) ([]*repositories.VirtualServer, int, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	items := r.filtered(filter)
+	return items, len(items), nil
+}
+
+func (r *VirtualServerRepository) Insert(virtualServer *repositories.VirtualServer) {
+	r.changeTracker.Add(change.NewEntry(change.Added, r.entityType, virtualServer))
+}
+
+func (r *VirtualServerRepository) Update(virtualServer *repositories.VirtualServer) {
+	r.changeTracker.Add(change.NewEntry(change.Updated, r.entityType, virtualServer))
+}

--- a/internal/repositories/memory/virtualservers.go
+++ b/internal/repositories/memory/virtualservers.go
@@ -47,7 +47,7 @@ func (r *VirtualServerRepository) filtered(filter *repositories.VirtualServerFil
 }
 
 func (r *VirtualServerRepository) FirstOrErr(_ context.Context, filter *repositories.VirtualServerFilter) (*repositories.VirtualServer, error) {
-	result, err := r.FirstOrNil(nil, filter)
+	result, err := r.FirstOrNil(context.TODO(), filter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repositories/paginginfo.go
+++ b/internal/repositories/paginginfo.go
@@ -22,3 +22,11 @@ func (i PagingInfo) Apply(s *sqlbuilder.SelectBuilder) {
 func (i PagingInfo) offset() int {
 	return (i.page - 1) * i.size
 }
+
+func (i PagingInfo) Page() int {
+	return i.page
+}
+
+func (i PagingInfo) Size() int {
+	return i.size
+}

--- a/internal/setup/database.go
+++ b/internal/setup/database.go
@@ -3,6 +3,7 @@ package setup
 import (
 	"github.com/The127/Keyline/internal/config"
 	"github.com/The127/Keyline/internal/database"
+	"github.com/The127/Keyline/internal/database/memory"
 	"github.com/The127/Keyline/internal/database/postgres"
 	"github.com/The127/Keyline/internal/logging"
 	"context"
@@ -24,6 +25,9 @@ func Database(dc *ioc.DependencyCollection, c config.DatabaseConfig) (database.D
 		if err != nil {
 			return nil, fmt.Errorf("connecting to postgres: %w", err)
 		}
+
+	case config.DatabaseModeMemory:
+		db = memory.NewMemoryDatabase()
 
 	default:
 		panic("database mode missing or not supported")

--- a/tests/e2e/backends_test.go
+++ b/tests/e2e/backends_test.go
@@ -1,0 +1,37 @@
+package e2e
+
+import (
+	"github.com/The127/Keyline/internal/config"
+	"github.com/The127/Keyline/internal/database/postgres"
+)
+
+// testBackend describes a database backend to run the test suite against.
+type testBackend struct {
+	name   string
+	dbMode config.DatabaseMode
+}
+
+// postgresBackendAvailable returns true when the test Postgres instance is reachable.
+func postgresBackendAvailable() bool {
+	pc := config.PostgresConfig{
+		Database: "postgres",
+		Host:     "localhost",
+		Port:     5732,
+		Username: "user",
+		Password: "password",
+		SslMode:  "disable",
+	}
+	db, err := postgres.ConnectToDatabase(pc)
+	if err != nil {
+		return false
+	}
+	_ = db.Close()
+	return true
+}
+
+// testBackends is the ordered list of backends the suite runs against.
+// Postgres is skipped at runtime when the server is unavailable.
+var testBackends = []testBackend{
+	{name: "postgres", dbMode: config.DatabaseModePostgres},
+	{name: "memory", dbMode: config.DatabaseModeMemory},
+}

--- a/tests/e2e/deviceflow_test.go
+++ b/tests/e2e/deviceflow_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/The127/Keyline/client"
 	"github.com/The127/Keyline/internal/authentication"
 	"github.com/The127/Keyline/internal/commands"
+	"github.com/The127/Keyline/internal/config"
 	"github.com/The127/Keyline/internal/database"
 	"github.com/The127/Keyline/internal/middlewares"
 	"github.com/The127/Keyline/internal/repositories"
@@ -26,119 +27,129 @@ const (
 	deviceUserPassword = "test-device-password-1"
 )
 
-var _ = Describe("Device Authorization Grant", Ordered, func() {
-	var h *harness
-	var deviceAppId uuid.UUID
+func init() {
+	for _, backend := range testBackends {
+		backend := backend
+		Describe("Device Authorization Grant ["+backend.name+"]", Ordered, func() {
+			var h *harness
+			var deviceAppId uuid.UUID
 
-	BeforeAll(func() {
-		h = newE2eTestHarness(nil)
-		var err error
-		deviceAppId, err = setupDeviceFlowFixtures(h.Scope())
-		Expect(err).ToNot(HaveOccurred())
-		_ = deviceAppId
-	})
+			BeforeAll(func() {
+				if backend.dbMode == config.DatabaseModePostgres && !postgresBackendAvailable() {
+					Skip("Postgres not available")
+				}
+				h = newE2eTestHarness(backend.dbMode, nil)
+				var err error
+				deviceAppId, err = setupDeviceFlowFixtures(h.Scope())
+				Expect(err).ToNot(HaveOccurred())
+				_ = deviceAppId
+			})
 
-	AfterAll(func() {
-		h.Close()
-	})
+			AfterAll(func() {
+				if h != nil {
+					h.Close()
+				}
+			})
 
-	Describe("POST /device", func() {
-		It("rejects missing client_id", func() {
-			_, err := h.Client().Oidc().BeginDeviceFlow(h.Ctx(), "", "openid")
-			Expect(err).To(HaveOccurred())
+			Describe("POST /device", func() {
+				It("rejects missing client_id", func() {
+					_, err := h.Client().Oidc().BeginDeviceFlow(h.Ctx(), "", "openid")
+					Expect(err).To(HaveOccurred())
+				})
+
+				It("rejects application without device flow enabled", func() {
+					_, err := h.Client().Oidc().BeginDeviceFlow(h.Ctx(), commands.AdminApplicationName, "openid")
+					Expect(err).To(HaveOccurred())
+				})
+
+				It("rejects missing openid scope", func() {
+					_, err := h.Client().Oidc().BeginDeviceFlow(h.Ctx(), deviceAppName, "profile")
+					Expect(err).To(HaveOccurred())
+				})
+
+				It("returns device authorization response", func() {
+					resp, err := h.Client().Oidc().BeginDeviceFlow(h.Ctx(), deviceAppName, "openid")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(resp.DeviceCode).ToNot(BeEmpty())
+					Expect(resp.UserCode).ToNot(BeEmpty())
+					Expect(resp.VerificationUri).ToNot(BeEmpty())
+					Expect(resp.VerificationUriComplete).ToNot(BeEmpty())
+					Expect(resp.ExpiresIn).To(BeEquivalentTo(600))
+					Expect(resp.Interval).To(BeEquivalentTo(5))
+				})
+			})
+
+			Describe("POST /activate", func() {
+				It("rejects unknown user_code", func() {
+					_, err := h.Client().Oidc().PostActivate(h.Ctx(), "XXXX-XXXX")
+					Expect(err).To(MatchError(client.ErrInvalidUserCode))
+				})
+			})
+
+			Describe("Full device authorization flow", func() {
+				It("issues tokens after user approves", func() {
+					// Step 1: CLI requests device authorization
+					deviceResp, err := h.Client().Oidc().BeginDeviceFlow(h.Ctx(), deviceAppName, "openid")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(deviceResp.DeviceCode).ToNot(BeEmpty())
+					Expect(deviceResp.UserCode).ToNot(BeEmpty())
+
+					// Step 2: Poll while pending
+					_, pollErr := h.Client().Oidc().PollDeviceToken(h.Ctx(), deviceAppName, deviceResp.DeviceCode)
+					Expect(pollErr).To(MatchError(client.ErrAuthorizationPending))
+
+					// Step 3: User submits user_code on activation page
+					loginToken, err := h.Client().Oidc().PostActivate(h.Ctx(), deviceResp.UserCode)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(loginToken).ToNot(BeEmpty())
+
+					// Step 4: User completes login (verify password)
+					err = h.Client().Oidc().VerifyPassword(h.Ctx(), loginToken, deviceUserUsername, deviceUserPassword)
+					Expect(err).ToNot(HaveOccurred())
+
+					// Step 5: Finish login — marks device code as authorized
+					err = h.Client().Oidc().FinishLogin(h.Ctx(), loginToken)
+					Expect(err).ToNot(HaveOccurred())
+
+					// Step 6: CLI polls and receives tokens
+					tokenResp, err := h.Client().Oidc().PollDeviceToken(h.Ctx(), deviceAppName, deviceResp.DeviceCode)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(tokenResp.AccessToken).ToNot(BeEmpty())
+					Expect(tokenResp.IdToken).ToNot(BeEmpty())
+					Expect(tokenResp.RefreshToken).ToNot(BeEmpty())
+					Expect(tokenResp.TokenType).To(Equal("Bearer"))
+				})
+
+				It("rejects double use of device_code", func() {
+					deviceResp, err := h.Client().Oidc().BeginDeviceFlow(h.Ctx(), deviceAppName, "openid")
+					Expect(err).ToNot(HaveOccurred())
+
+					loginToken, err := h.Client().Oidc().PostActivate(h.Ctx(), deviceResp.UserCode)
+					Expect(err).ToNot(HaveOccurred())
+
+					err = h.Client().Oidc().VerifyPassword(h.Ctx(), loginToken, deviceUserUsername, deviceUserPassword)
+					Expect(err).ToNot(HaveOccurred())
+
+					err = h.Client().Oidc().FinishLogin(h.Ctx(), loginToken)
+					Expect(err).ToNot(HaveOccurred())
+
+					// First poll succeeds
+					_, err = h.Client().Oidc().PollDeviceToken(h.Ctx(), deviceAppName, deviceResp.DeviceCode)
+					Expect(err).ToNot(HaveOccurred())
+
+					// Second poll fails — one-time use
+					_, err = h.Client().Oidc().PollDeviceToken(h.Ctx(), deviceAppName, deviceResp.DeviceCode)
+					Expect(err).To(MatchError(client.ErrExpiredToken))
+				})
+
+				It("returns expired_token for unknown device_code", func() {
+					_, err := h.Client().Oidc().PollDeviceToken(h.Ctx(), deviceAppName, "nonexistent-device-code")
+					Expect(err).To(MatchError(client.ErrExpiredToken))
+				})
+			})
 		})
-
-		It("rejects application without device flow enabled", func() {
-			_, err := h.Client().Oidc().BeginDeviceFlow(h.Ctx(), commands.AdminApplicationName, "openid")
-			Expect(err).To(HaveOccurred())
-		})
-
-		It("rejects missing openid scope", func() {
-			_, err := h.Client().Oidc().BeginDeviceFlow(h.Ctx(), deviceAppName, "profile")
-			Expect(err).To(HaveOccurred())
-		})
-
-		It("returns device authorization response", func() {
-			resp, err := h.Client().Oidc().BeginDeviceFlow(h.Ctx(), deviceAppName, "openid")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(resp.DeviceCode).ToNot(BeEmpty())
-			Expect(resp.UserCode).ToNot(BeEmpty())
-			Expect(resp.VerificationUri).ToNot(BeEmpty())
-			Expect(resp.VerificationUriComplete).ToNot(BeEmpty())
-			Expect(resp.ExpiresIn).To(BeEquivalentTo(600))
-			Expect(resp.Interval).To(BeEquivalentTo(5))
-		})
-	})
-
-	Describe("POST /activate", func() {
-		It("rejects unknown user_code", func() {
-			_, err := h.Client().Oidc().PostActivate(h.Ctx(), "XXXX-XXXX")
-			Expect(err).To(MatchError(client.ErrInvalidUserCode))
-		})
-	})
-
-	Describe("Full device authorization flow", func() {
-		It("issues tokens after user approves", func() {
-			// Step 1: CLI requests device authorization
-			deviceResp, err := h.Client().Oidc().BeginDeviceFlow(h.Ctx(), deviceAppName, "openid")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(deviceResp.DeviceCode).ToNot(BeEmpty())
-			Expect(deviceResp.UserCode).ToNot(BeEmpty())
-
-			// Step 2: Poll while pending
-			_, pollErr := h.Client().Oidc().PollDeviceToken(h.Ctx(), deviceAppName, deviceResp.DeviceCode)
-			Expect(pollErr).To(MatchError(client.ErrAuthorizationPending))
-
-			// Step 3: User submits user_code on activation page
-			loginToken, err := h.Client().Oidc().PostActivate(h.Ctx(), deviceResp.UserCode)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(loginToken).ToNot(BeEmpty())
-
-			// Step 4: User completes login (verify password)
-			err = h.Client().Oidc().VerifyPassword(h.Ctx(), loginToken, deviceUserUsername, deviceUserPassword)
-			Expect(err).ToNot(HaveOccurred())
-
-			// Step 5: Finish login — marks device code as authorized
-			err = h.Client().Oidc().FinishLogin(h.Ctx(), loginToken)
-			Expect(err).ToNot(HaveOccurred())
-
-			// Step 6: CLI polls and receives tokens
-			tokenResp, err := h.Client().Oidc().PollDeviceToken(h.Ctx(), deviceAppName, deviceResp.DeviceCode)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(tokenResp.AccessToken).ToNot(BeEmpty())
-			Expect(tokenResp.IdToken).ToNot(BeEmpty())
-			Expect(tokenResp.RefreshToken).ToNot(BeEmpty())
-			Expect(tokenResp.TokenType).To(Equal("Bearer"))
-		})
-
-		It("rejects double use of device_code", func() {
-			deviceResp, err := h.Client().Oidc().BeginDeviceFlow(h.Ctx(), deviceAppName, "openid")
-			Expect(err).ToNot(HaveOccurred())
-
-			loginToken, err := h.Client().Oidc().PostActivate(h.Ctx(), deviceResp.UserCode)
-			Expect(err).ToNot(HaveOccurred())
-
-			err = h.Client().Oidc().VerifyPassword(h.Ctx(), loginToken, deviceUserUsername, deviceUserPassword)
-			Expect(err).ToNot(HaveOccurred())
-
-			err = h.Client().Oidc().FinishLogin(h.Ctx(), loginToken)
-			Expect(err).ToNot(HaveOccurred())
-
-			// First poll succeeds
-			_, err = h.Client().Oidc().PollDeviceToken(h.Ctx(), deviceAppName, deviceResp.DeviceCode)
-			Expect(err).ToNot(HaveOccurred())
-
-			// Second poll fails — one-time use
-			_, err = h.Client().Oidc().PollDeviceToken(h.Ctx(), deviceAppName, deviceResp.DeviceCode)
-			Expect(err).To(MatchError(client.ErrExpiredToken))
-		})
-
-		It("returns expired_token for unknown device_code", func() {
-			_, err := h.Client().Oidc().PollDeviceToken(h.Ctx(), deviceAppName, "nonexistent-device-code")
-			Expect(err).To(MatchError(client.ErrExpiredToken))
-		})
-	})
-})
+	}
+}
 
 func setupDeviceFlowFixtures(scope *ioc.DependencyProvider) (uuid.UUID, error) {
 	subscope := scope.NewScope()

--- a/tests/e2e/harness.go
+++ b/tests/e2e/harness.go
@@ -39,6 +39,7 @@ type harness struct {
 	ctx       context.Context
 	setTime   clock.TimeSetterFn
 	dbName    string
+	dbMode    config.DatabaseMode
 	scope     *ioc.DependencyProvider
 	serverUrl string
 }
@@ -64,6 +65,12 @@ func (h *harness) Close() {
 	dbConnection := ioc.GetDependency[database.Database](h.scope)
 	utils.PanicOnError(h.scope.Close, "closing scope")
 	utils.PanicOnError(dbConnection.Close, "closing db connection in test")
+
+	// For Postgres we need to drop the temporary database we created.
+	// For memory there is nothing to tear down.
+	if h.dbMode != config.DatabaseModePostgres {
+		return
+	}
 
 	pc := config.PostgresConfig{
 		Database: "postgres",
@@ -97,39 +104,54 @@ func (h *harness) Scope() *ioc.DependencyProvider {
 	return h.scope
 }
 
-func newE2eTestHarness(tokenSourceGenerator func(ctx context.Context, url string) oauth2.TokenSource) *harness {
+func newE2eTestHarness(dbMode config.DatabaseMode, tokenSourceGenerator func(ctx context.Context, url string) oauth2.TokenSource) *harness {
 	ctx := context.Background()
 	dc := ioc.NewDependencyCollection()
 	clockService, timeSetter := clock.NewMockClock(time.Now())
 
-	sqlbuilder.DefaultFlavor = sqlbuilder.PostgreSQL
+	var dbName string
+	var c config.DatabaseConfig
 
-	dbName := strings.ReplaceAll("keyline_test_"+uuid.New().String(), "-", "")
-	c := config.DatabaseConfig{
-		Mode: config.DatabaseModePostgres,
-		Postgres: config.PostgresConfig{
-			Database: "postgres",
-			Host:     "localhost",
-			Port:     5732,
-			Username: "user",
-			Password: "password",
-			SslMode:  "disable",
-		},
+	switch dbMode {
+	case config.DatabaseModePostgres:
+		sqlbuilder.DefaultFlavor = sqlbuilder.PostgreSQL
+
+		dbName = strings.ReplaceAll("keyline_test_"+uuid.New().String(), "-", "")
+		c = config.DatabaseConfig{
+			Mode: config.DatabaseModePostgres,
+			Postgres: config.PostgresConfig{
+				Database: "postgres",
+				Host:     "localhost",
+				Port:     5732,
+				Username: "user",
+				Password: "password",
+				SslMode:  "disable",
+			},
+		}
+
+		initDb, err := postgres.ConnectToDatabase(c.Postgres)
+		if err != nil {
+			panic(err)
+		}
+
+		createQuery := fmt.Sprintf("create database %s;", dbName)
+		_, err = initDb.Exec(createQuery)
+		if err != nil {
+			panic(err)
+		}
+		utils.PanicOnError(initDb.Close, "closing initial db connection in test")
+
+		c.Postgres.Database = dbName
+
+	case config.DatabaseModeMemory:
+		c = config.DatabaseConfig{
+			Mode: config.DatabaseModeMemory,
+		}
+
+	default:
+		panic(fmt.Sprintf("unsupported database mode in test harness: %s", dbMode))
 	}
 
-	initDb, err := postgres.ConnectToDatabase(c.Postgres)
-	if err != nil {
-		panic(err)
-	}
-
-	createQuery := fmt.Sprintf("create database %s;", dbName)
-	_, err = initDb.Exec(createQuery)
-	if err != nil {
-		panic(err)
-	}
-	utils.PanicOnError(initDb.Close, "closing initial db connection in test")
-
-	c.Postgres.Database = dbName
 	db, err := setup.Database(dc, c)
 	if err != nil {
 		panic(fmt.Errorf("failed to create test database: %w", err))
@@ -145,16 +167,26 @@ func newE2eTestHarness(tokenSourceGenerator func(ctx context.Context, url string
 	})
 	setup.OutboxDelivery(dc, config.QueueModeNoop)
 
-	vaultPath := fmt.Sprintf("%s/", uuid.New().String())
-	setup.KeyServices(dc, config.KeyStoreConfig{
-		Mode: config.KeyStoreModeVault,
-		Vault: config.VaultKeyStoreConfig{
-			Address: "http://localhost:8222",
-			Token:   "myroot",
-			Mount:   "secret",
-			Prefix:  vaultPath,
-		},
-	})
+	// Postgres harness uses Vault key storage (requires a running Vault instance);
+	// Memory harness uses the in-process memory key store to stay dependency-free.
+	var keyStoreConfig config.KeyStoreConfig
+	if dbMode == config.DatabaseModePostgres {
+		vaultPath := fmt.Sprintf("%s/", uuid.New().String())
+		keyStoreConfig = config.KeyStoreConfig{
+			Mode: config.KeyStoreModeVault,
+			Vault: config.VaultKeyStoreConfig{
+				Address: "http://localhost:8222",
+				Token:   "myroot",
+				Mount:   "secret",
+				Prefix:  vaultPath,
+			},
+		}
+	} else {
+		keyStoreConfig = config.KeyStoreConfig{
+			Mode: config.KeyStoreModeMemory,
+		}
+	}
+	setup.KeyServices(dc, keyStoreConfig)
 
 	setup.Caching(dc, config.CacheModeMemory)
 	setup.Services(dc)
@@ -192,6 +224,7 @@ func newE2eTestHarness(tokenSourceGenerator func(ctx context.Context, url string
 		ctx:       ctx,
 		setTime:   timeSetter,
 		dbName:    dbName,
+		dbMode:    dbMode,
 		serverUrl: serverConfig.ExternalUrl,
 	}
 }

--- a/tests/e2e/serviceuserlogin_test.go
+++ b/tests/e2e/serviceuserlogin_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"github.com/The127/Keyline/internal/commands"
+	"github.com/The127/Keyline/internal/config"
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
@@ -14,85 +15,95 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Service user login", Ordered, func() {
-	var h *harness
+const wrongPrivateKey = "-----BEGIN PRIVATE KEY-----\nMFECAQEwBQYDK2VwBCIEIGlwiAvmqJTxz8n1Ewwwy7/XG2LJphqbOhfKcfg2l9YU\ngSEAi+MvQpVxlYdQrbbsn5xltPOYbU00qJtkEHPO2uzUmKQ=\n-----END PRIVATE KEY-----\n"
 
-	const wrongPrivateKey = "-----BEGIN PRIVATE KEY-----\nMFECAQEwBQYDK2VwBCIEIGlwiAvmqJTxz8n1Ewwwy7/XG2LJphqbOhfKcfg2l9YU\ngSEAi+MvQpVxlYdQrbbsn5xltPOYbU00qJtkEHPO2uzUmKQ=\n-----END PRIVATE KEY-----\n"
+func init() {
+	for _, backend := range testBackends {
+		backend := backend
+		Describe("Service user login ["+backend.name+"]", Ordered, func() {
+			var h *harness
 
-	BeforeAll(func() {
-		h = newE2eTestHarness(nil)
-	})
+			BeforeAll(func() {
+				if backend.dbMode == config.DatabaseModePostgres && !postgresBackendAvailable() {
+					Skip("Postgres not available")
+				}
+				h = newE2eTestHarness(backend.dbMode, nil)
+			})
 
-	AfterAll(func() {
-		h.Close()
-	})
+			AfterAll(func() {
+				if h != nil {
+					h.Close()
+				}
+			})
 
-	It("fails with wrong private key", func() {
-		block, _ := pem.Decode([]byte(wrongPrivateKey))
-		if block == nil {
-			panic("failed to decode PEM")
-		}
+			It("fails with wrong private key", func() {
+				block, _ := pem.Decode([]byte(wrongPrivateKey))
+				if block == nil {
+					panic("failed to decode PEM")
+				}
 
-		key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
-		Expect(err).ToNot(HaveOccurred())
+				key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+				Expect(err).ToNot(HaveOccurred())
 
-		claims := jwt.MapClaims{
-			"aud":    commands.AdminApplicationName,
-			"iss":    serviceUserUsername,
-			"sub":    serviceUserUsername,
-			"scopes": "openid profile email",
-		}
-		jwtToken := jwt.NewWithClaims(jwt.SigningMethodEdDSA, claims)
-		jwtToken.Header["kid"] = serviceUserKid
-		signedJWT, err := jwtToken.SignedString(key)
-		Expect(err).ToNot(HaveOccurred())
+				claims := jwt.MapClaims{
+					"aud":    commands.AdminApplicationName,
+					"iss":    serviceUserUsername,
+					"sub":    serviceUserUsername,
+					"scopes": "openid profile email",
+				}
+				jwtToken := jwt.NewWithClaims(jwt.SigningMethodEdDSA, claims)
+				jwtToken.Header["kid"] = serviceUserKid
+				signedJWT, err := jwtToken.SignedString(key)
+				Expect(err).ToNot(HaveOccurred())
 
-		resp, err := http.PostForm(fmt.Sprintf("%s/oidc/%s/token", h.ApiUrl(), h.VirtualServer()),
-			url.Values{
-				"grant_type":         {"urn:ietf:params:oauth:grant-type:token-exchange"},
-				"subject_token":      {signedJWT},
-				"subject_token_type": {"urn:ietf:params:oauth:token-type:access_token"},
-			},
-		)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(resp.StatusCode).ToNot(Equal(http.StatusOK))
-	})
+				resp, err := http.PostForm(fmt.Sprintf("%s/oidc/%s/token", h.ApiUrl(), h.VirtualServer()),
+					url.Values{
+						"grant_type":         {"urn:ietf:params:oauth:grant-type:token-exchange"},
+						"subject_token":      {signedJWT},
+						"subject_token_type": {"urn:ietf:params:oauth:token-type:access_token"},
+					},
+				)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resp.StatusCode).ToNot(Equal(http.StatusOK))
+			})
 
-	It("exchanges token successfully", func() {
-		block, _ := pem.Decode([]byte(serviceUserPrivateKey))
-		if block == nil {
-			panic("failed to decode PEM")
-		}
+			It("exchanges token successfully", func() {
+				block, _ := pem.Decode([]byte(serviceUserPrivateKey))
+				if block == nil {
+					panic("failed to decode PEM")
+				}
 
-		key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
-		Expect(err).ToNot(HaveOccurred())
+				key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+				Expect(err).ToNot(HaveOccurred())
 
-		claims := jwt.MapClaims{
-			"aud":    commands.AdminApplicationName,
-			"iss":    serviceUserUsername,
-			"sub":    serviceUserUsername,
-			"scopes": "openid profile email",
-		}
-		jwtToken := jwt.NewWithClaims(jwt.SigningMethodEdDSA, claims)
-		jwtToken.Header["kid"] = serviceUserKid
-		signedJWT, err := jwtToken.SignedString(key)
-		Expect(err).ToNot(HaveOccurred())
+				claims := jwt.MapClaims{
+					"aud":    commands.AdminApplicationName,
+					"iss":    serviceUserUsername,
+					"sub":    serviceUserUsername,
+					"scopes": "openid profile email",
+				}
+				jwtToken := jwt.NewWithClaims(jwt.SigningMethodEdDSA, claims)
+				jwtToken.Header["kid"] = serviceUserKid
+				signedJWT, err := jwtToken.SignedString(key)
+				Expect(err).ToNot(HaveOccurred())
 
-		resp, err := http.PostForm(fmt.Sprintf("%s/oidc/%s/token", h.ApiUrl(), h.VirtualServer()),
-			url.Values{
-				"grant_type":         {"urn:ietf:params:oauth:grant-type:token-exchange"},
-				"subject_token":      {signedJWT},
-				"subject_token_type": {"urn:ietf:params:oauth:token-type:access_token"},
-			},
-		)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+				resp, err := http.PostForm(fmt.Sprintf("%s/oidc/%s/token", h.ApiUrl(), h.VirtualServer()),
+					url.Values{
+						"grant_type":         {"urn:ietf:params:oauth:grant-type:token-exchange"},
+						"subject_token":      {signedJWT},
+						"subject_token_type": {"urn:ietf:params:oauth:token-type:access_token"},
+					},
+				)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
-		var responseJson map[string]any
-		err = json.NewDecoder(resp.Body).Decode(
-			&responseJson,
-		)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(responseJson["access_token"]).ToNot(BeEmpty())
-	})
-})
+				var responseJson map[string]any
+				err = json.NewDecoder(resp.Body).Decode(
+					&responseJson,
+				)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(responseJson["access_token"]).ToNot(BeEmpty())
+			})
+		})
+	}
+}

--- a/tests/e2e/unauthorized_test.go
+++ b/tests/e2e/unauthorized_test.go
@@ -2,25 +2,36 @@ package e2e
 
 import (
 	"github.com/The127/Keyline/client"
+	"github.com/The127/Keyline/internal/config"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Unauthorized", Ordered, func() {
-	var h *harness
+func init() {
+	for _, backend := range testBackends {
+		backend := backend
+		Describe("Unauthorized ["+backend.name+"]", Ordered, func() {
+			var h *harness
 
-	BeforeAll(func() {
-		h = newE2eTestHarness(nil)
-	})
+			BeforeAll(func() {
+				if backend.dbMode == config.DatabaseModePostgres && !postgresBackendAvailable() {
+					Skip("Postgres not available")
+				}
+				h = newE2eTestHarness(backend.dbMode, nil)
+			})
 
-	AfterAll(func() {
-		h.Close()
-	})
+			AfterAll(func() {
+				if h != nil {
+					h.Close()
+				}
+			})
 
-	It("rejects requests", func() {
-		_, err := h.Client().User().List(h.Ctx(), client.ListUserParams{})
-		Expect(err).To(HaveOccurred())
-		Expect(err).To(MatchError(ContainSubstring("401 Unauthorized")))
-	})
-})
+			It("rejects requests", func() {
+				_, err := h.Client().User().List(h.Ctx(), client.ListUserParams{})
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(ContainSubstring("401 Unauthorized")))
+			})
+		})
+	}
+}

--- a/tests/integration/application_flow_test.go
+++ b/tests/integration/application_flow_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"github.com/The127/Keyline/internal/commands"
+	"github.com/The127/Keyline/internal/config"
 	"github.com/The127/Keyline/internal/queries"
 	"github.com/The127/Keyline/internal/repositories"
 	"github.com/The127/Keyline/utils"
@@ -14,106 +15,116 @@ import (
 	"github.com/onsi/gomega/gstruct"
 )
 
-var _ = Describe("Application flow", Ordered, func() {
-	var h *harness
+func init() {
+	for _, backend := range testBackends {
+		backend := backend
+		Describe("Application flow ["+backend.name+"]", Ordered, func() {
+			var h *harness
 
-	projectSlug := "test-project"
-	var applicationId uuid.UUID
+			projectSlug := "test-project"
+			var applicationId uuid.UUID
 
-	BeforeAll(func() {
-		h = newIntegrationTestHarness()
+			BeforeAll(func() {
+				if backend.dbMode == config.DatabaseModePostgres && !postgresBackendAvailable() {
+					Skip("Postgres not available")
+				}
+				h = newIntegrationTestHarness(backend.dbMode)
 
-		req := commands.CreateProject{
-			VirtualServerName: h.VirtualServer(),
-			Slug:              projectSlug,
-			Name:              "Name",
-			Description:       "Description",
-		}
-		_, err := mediatr.Send[*commands.CreateProjectResponse](h.Ctx(), h.Mediator(), req)
-		Expect(err).ToNot(HaveOccurred())
+				req := commands.CreateProject{
+					VirtualServerName: h.VirtualServer(),
+					Slug:              projectSlug,
+					Name:              "Name",
+					Description:       "Description",
+				}
+				_, err := mediatr.Send[*commands.CreateProjectResponse](h.Ctx(), h.Mediator(), req)
+				Expect(err).ToNot(HaveOccurred())
 
-		Expect(h.dbContext.SaveChanges(h.ctx)).ToNot(HaveOccurred())
-	})
+				Expect(h.dbContext.SaveChanges(h.ctx)).ToNot(HaveOccurred())
+			})
 
-	AfterAll(func() {
-		h.Close()
-	})
+			AfterAll(func() {
+				if h != nil {
+					h.Close()
+				}
+			})
 
-	It("should persist public application successfully", func() {
-		req := commands.CreateApplication{
-			VirtualServerName:      h.VirtualServer(),
-			ProjectSlug:            projectSlug,
-			Name:                   "test-app",
-			DisplayName:            "Test App",
-			Type:                   repositories.ApplicationTypePublic,
-			RedirectUris:           []string{"http://localhost:8080/callback"},
-			PostLogoutRedirectUris: []string{"http://localhost:8080/logout"},
-		}
-		response, err := mediatr.Send[*commands.CreateApplicationResponse](h.Ctx(), h.Mediator(), req)
-		Expect(err).ToNot(HaveOccurred())
-		applicationId = response.Id
+			It("should persist public application successfully", func() {
+				req := commands.CreateApplication{
+					VirtualServerName:      h.VirtualServer(),
+					ProjectSlug:            projectSlug,
+					Name:                   "test-app",
+					DisplayName:            "Test App",
+					Type:                   repositories.ApplicationTypePublic,
+					RedirectUris:           []string{"http://localhost:8080/callback"},
+					PostLogoutRedirectUris: []string{"http://localhost:8080/logout"},
+				}
+				response, err := mediatr.Send[*commands.CreateApplicationResponse](h.Ctx(), h.Mediator(), req)
+				Expect(err).ToNot(HaveOccurred())
+				applicationId = response.Id
 
-		Expect(h.dbContext.SaveChanges(h.ctx)).ToNot(HaveOccurred())
-	})
+				Expect(h.dbContext.SaveChanges(h.ctx)).ToNot(HaveOccurred())
+			})
 
-	It("should list applications successfully", func() {
-		req := queries.ListApplications{
-			VirtualServerName: h.VirtualServer(),
-			ProjectSlug:       projectSlug,
-			SearchText:        "test-app",
-		}
-		response, err := mediatr.Send[*queries.ListApplicationsResponse](h.Ctx(), h.Mediator(), req)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(response.Items).To(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-			"Id":   Equal(applicationId),
-			"Name": Equal("test-app"),
-		})))
-	})
+			It("should list applications successfully", func() {
+				req := queries.ListApplications{
+					VirtualServerName: h.VirtualServer(),
+					ProjectSlug:       projectSlug,
+					SearchText:        "test-app",
+				}
+				response, err := mediatr.Send[*queries.ListApplicationsResponse](h.Ctx(), h.Mediator(), req)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.Items).To(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+					"Id":   Equal(applicationId),
+					"Name": Equal("test-app"),
+				})))
+			})
 
-	It("should edit application successfully", func() {
-		cmd := commands.PatchApplication{
-			VirtualServerName: h.VirtualServer(),
-			ProjectSlug:       projectSlug,
-			ApplicationId:     applicationId,
-			DisplayName:       utils.Ptr("Updated Test App"),
-		}
-		_, err := mediatr.Send[*commands.PatchApplicationResponse](h.Ctx(), h.Mediator(), cmd)
-		Expect(err).ToNot(HaveOccurred())
+			It("should edit application successfully", func() {
+				cmd := commands.PatchApplication{
+					VirtualServerName: h.VirtualServer(),
+					ProjectSlug:       projectSlug,
+					ApplicationId:     applicationId,
+					DisplayName:       utils.Ptr("Updated Test App"),
+				}
+				_, err := mediatr.Send[*commands.PatchApplicationResponse](h.Ctx(), h.Mediator(), cmd)
+				Expect(err).ToNot(HaveOccurred())
 
-		Expect(h.dbContext.SaveChanges(h.ctx)).ToNot(HaveOccurred())
-	})
+				Expect(h.dbContext.SaveChanges(h.ctx)).ToNot(HaveOccurred())
+			})
 
-	It("should reflect updated values", func() {
-		req := queries.GetApplication{
-			VirtualServerName: h.VirtualServer(),
-			ProjectSlug:       projectSlug,
-			ApplicationId:     applicationId,
-		}
-		app, err := mediatr.Send[*queries.GetApplicationResult](h.Ctx(), h.Mediator(), req)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(app.DisplayName).To(Equal("Updated Test App"))
-	})
+			It("should reflect updated values", func() {
+				req := queries.GetApplication{
+					VirtualServerName: h.VirtualServer(),
+					ProjectSlug:       projectSlug,
+					ApplicationId:     applicationId,
+				}
+				app, err := mediatr.Send[*queries.GetApplicationResult](h.Ctx(), h.Mediator(), req)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(app.DisplayName).To(Equal("Updated Test App"))
+			})
 
-	It("should delete application successfully", func() {
-		cmd := commands.DeleteApplication{
-			VirtualServerName: h.VirtualServer(),
-			ProjectSlug:       projectSlug,
-			ApplicationId:     applicationId,
-		}
-		_, err := mediatr.Send[*commands.DeleteApplicationResponse](h.Ctx(), h.Mediator(), cmd)
-		Expect(err).ToNot(HaveOccurred())
+			It("should delete application successfully", func() {
+				cmd := commands.DeleteApplication{
+					VirtualServerName: h.VirtualServer(),
+					ProjectSlug:       projectSlug,
+					ApplicationId:     applicationId,
+				}
+				_, err := mediatr.Send[*commands.DeleteApplicationResponse](h.Ctx(), h.Mediator(), cmd)
+				Expect(err).ToNot(HaveOccurred())
 
-		Expect(h.dbContext.SaveChanges(h.ctx)).ToNot(HaveOccurred())
-	})
+				Expect(h.dbContext.SaveChanges(h.ctx)).ToNot(HaveOccurred())
+			})
 
-	It("should not list deleted application", func() {
-		req := queries.ListApplications{
-			VirtualServerName: h.VirtualServer(),
-			ProjectSlug:       projectSlug,
-			SearchText:        "test-app",
-		}
-		response, err := mediatr.Send[*queries.ListApplicationsResponse](h.Ctx(), h.Mediator(), req)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(response.Items).To(BeEmpty())
-	})
-})
+			It("should not list deleted application", func() {
+				req := queries.ListApplications{
+					VirtualServerName: h.VirtualServer(),
+					ProjectSlug:       projectSlug,
+					SearchText:        "test-app",
+				}
+				response, err := mediatr.Send[*queries.ListApplicationsResponse](h.Ctx(), h.Mediator(), req)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.Items).To(BeEmpty())
+			})
+		})
+	}
+}

--- a/tests/integration/backends_test.go
+++ b/tests/integration/backends_test.go
@@ -1,0 +1,37 @@
+package integration
+
+import (
+	"github.com/The127/Keyline/internal/config"
+	"github.com/The127/Keyline/internal/database/postgres"
+)
+
+// testBackend describes a database backend to run the test suite against.
+type testBackend struct {
+	name   string
+	dbMode config.DatabaseMode
+}
+
+// postgresBackendAvailable returns true when the test Postgres instance is reachable.
+func postgresBackendAvailable() bool {
+	pc := config.PostgresConfig{
+		Database: "postgres",
+		Host:     "localhost",
+		Port:     5732,
+		Username: "user",
+		Password: "password",
+		SslMode:  "disable",
+	}
+	db, err := postgres.ConnectToDatabase(pc)
+	if err != nil {
+		return false
+	}
+	_ = db.Close()
+	return true
+}
+
+// testBackends is the ordered list of backends the suite runs against.
+// Postgres is skipped at runtime when the server is unavailable.
+var testBackends = []testBackend{
+	{name: "postgres", dbMode: config.DatabaseModePostgres},
+	{name: "memory", dbMode: config.DatabaseModeMemory},
+}

--- a/tests/integration/harness.go
+++ b/tests/integration/harness.go
@@ -29,6 +29,7 @@ type harness struct {
 	ctx       context.Context
 	setTime   clock.TimeSetterFn
 	dbName    string
+	dbMode    config.DatabaseMode
 	dbContext db2.Context
 }
 
@@ -36,6 +37,12 @@ func (h *harness) Close() {
 	dbConnection := ioc.GetDependency[db2.Database](h.scope)
 	utils.PanicOnError(h.scope.Close, "closing scope")
 	utils.PanicOnError(dbConnection.Close, "closing db connection in test")
+
+	// For Postgres we need to drop the temporary database we created.
+	// For memory there is nothing to tear down.
+	if h.dbMode != config.DatabaseModePostgres {
+		return
+	}
 
 	pc := config.PostgresConfig{
 		Database: "postgres",
@@ -77,39 +84,54 @@ func (h *harness) Mediator() mediatr.Mediator {
 	return h.m
 }
 
-func newIntegrationTestHarness() *harness {
+func newIntegrationTestHarness(dbMode config.DatabaseMode) *harness {
 	ctx := context.Background()
 	dc := ioc.NewDependencyCollection()
 	c, timeSetter := clock.NewMockClock(time.Now())
 
-	sqlbuilder.DefaultFlavor = sqlbuilder.PostgreSQL
+	var dbName string
+	var dbc config.DatabaseConfig
 
-	dbName := strings.ReplaceAll("keyline_test_"+uuid.New().String(), "-", "")
-	dbc := config.DatabaseConfig{
-		Mode: config.DatabaseModePostgres,
-		Postgres: config.PostgresConfig{
-			Database: "postgres",
-			Host:     "localhost",
-			Port:     5732,
-			Username: "user",
-			Password: "password",
-			SslMode:  "disable",
-		},
+	switch dbMode {
+	case config.DatabaseModePostgres:
+		sqlbuilder.DefaultFlavor = sqlbuilder.PostgreSQL
+
+		dbName = strings.ReplaceAll("keyline_test_"+uuid.New().String(), "-", "")
+		dbc = config.DatabaseConfig{
+			Mode: config.DatabaseModePostgres,
+			Postgres: config.PostgresConfig{
+				Database: "postgres",
+				Host:     "localhost",
+				Port:     5732,
+				Username: "user",
+				Password: "password",
+				SslMode:  "disable",
+			},
+		}
+
+		initDb, err := postgres.ConnectToDatabase(dbc.Postgres)
+		if err != nil {
+			panic(err)
+		}
+
+		createQuery := fmt.Sprintf("create database %s;", dbName)
+		_, err = initDb.Exec(createQuery)
+		if err != nil {
+			panic(err)
+		}
+		utils.PanicOnError(initDb.Close, "closing initial db connection in test")
+
+		dbc.Postgres.Database = dbName
+
+	case config.DatabaseModeMemory:
+		dbc = config.DatabaseConfig{
+			Mode: config.DatabaseModeMemory,
+		}
+
+	default:
+		panic(fmt.Sprintf("unsupported database mode in test harness: %s", dbMode))
 	}
 
-	initDb, err := postgres.ConnectToDatabase(dbc.Postgres)
-	if err != nil {
-		panic(err)
-	}
-
-	createQuery := fmt.Sprintf("create database %s;", dbName)
-	_, err = initDb.Exec(createQuery)
-	if err != nil {
-		panic(err)
-	}
-	utils.PanicOnError(initDb.Close, "closing initial db connection in test")
-
-	dbc.Postgres.Database = dbName
 	db, err := setup.Database(dc, dbc)
 	if err != nil {
 		panic(fmt.Errorf("failed to create test database: %w", err))
@@ -159,6 +181,7 @@ func newIntegrationTestHarness() *harness {
 		ctx:       ctx,
 		setTime:   timeSetter,
 		dbName:    dbName,
+		dbMode:    dbMode,
 		dbContext: dbContext,
 	}
 }

--- a/tests/integration/project_flow_test.go
+++ b/tests/integration/project_flow_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"github.com/The127/Keyline/internal/commands"
+	"github.com/The127/Keyline/internal/config"
 	"github.com/The127/Keyline/internal/queries"
 	"github.com/The127/Keyline/utils"
 
@@ -13,68 +14,78 @@ import (
 	"github.com/onsi/gomega/gstruct"
 )
 
-var _ = Describe("Project flow", Ordered, func() {
-	var h *harness
+func init() {
+	for _, backend := range testBackends {
+		backend := backend
+		Describe("Project flow ["+backend.name+"]", Ordered, func() {
+			var h *harness
 
-	projectSlug := "test-project"
-	var projectId uuid.UUID
+			projectSlug := "test-project"
+			var projectId uuid.UUID
 
-	BeforeAll(func() {
-		h = newIntegrationTestHarness()
-	})
+			BeforeAll(func() {
+				if backend.dbMode == config.DatabaseModePostgres && !postgresBackendAvailable() {
+					Skip("Postgres not available")
+				}
+				h = newIntegrationTestHarness(backend.dbMode)
+			})
 
-	AfterAll(func() {
-		h.Close()
-	})
+			AfterAll(func() {
+				if h != nil {
+					h.Close()
+				}
+			})
 
-	It("should create a project successfully", func() {
-		req := commands.CreateProject{
-			VirtualServerName: h.VirtualServer(),
-			Slug:              projectSlug,
-			Name:              "Name",
-			Description:       "Description",
-		}
-		response, err := mediatr.Send[*commands.CreateProjectResponse](h.Ctx(), h.Mediator(), req)
-		Expect(err).ToNot(HaveOccurred())
-		projectId = response.Id
+			It("should create a project successfully", func() {
+				req := commands.CreateProject{
+					VirtualServerName: h.VirtualServer(),
+					Slug:              projectSlug,
+					Name:              "Name",
+					Description:       "Description",
+				}
+				response, err := mediatr.Send[*commands.CreateProjectResponse](h.Ctx(), h.Mediator(), req)
+				Expect(err).ToNot(HaveOccurred())
+				projectId = response.Id
 
-		Expect(h.dbContext.SaveChanges(h.ctx)).ToNot(HaveOccurred())
-	})
+				Expect(h.dbContext.SaveChanges(h.ctx)).ToNot(HaveOccurred())
+			})
 
-	It("should list the project successfully", func() {
-		req := queries.ListProjects{
-			VirtualServerName: h.VirtualServer(),
-			SearchText:        "test",
-		}
-		response, err := mediatr.Send[*queries.ListProjectsResponse](h.Ctx(), h.Mediator(), req)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(response.Items).To(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-			"Id":   Equal(projectId),
-			"Slug": Equal(projectSlug),
-		})))
-	})
+			It("should list the project successfully", func() {
+				req := queries.ListProjects{
+					VirtualServerName: h.VirtualServer(),
+					SearchText:        "test",
+				}
+				response, err := mediatr.Send[*queries.ListProjectsResponse](h.Ctx(), h.Mediator(), req)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.Items).To(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+					"Id":   Equal(projectId),
+					"Slug": Equal(projectSlug),
+				})))
+			})
 
-	It("should edit the project successfully", func() {
-		req := commands.PatchProject{
-			VirtualServerName: h.VirtualServer(),
-			Slug:              projectSlug,
-			Name:              utils.Ptr("Updated Name"),
-			Description:       utils.Ptr("Updated Description"),
-		}
-		_, err := mediatr.Send[*commands.PatchProjectResponse](h.Ctx(), h.Mediator(), req)
-		Expect(err).ToNot(HaveOccurred())
+			It("should edit the project successfully", func() {
+				req := commands.PatchProject{
+					VirtualServerName: h.VirtualServer(),
+					Slug:              projectSlug,
+					Name:              utils.Ptr("Updated Name"),
+					Description:       utils.Ptr("Updated Description"),
+				}
+				_, err := mediatr.Send[*commands.PatchProjectResponse](h.Ctx(), h.Mediator(), req)
+				Expect(err).ToNot(HaveOccurred())
 
-		Expect(h.dbContext.SaveChanges(h.ctx)).ToNot(HaveOccurred())
-	})
+				Expect(h.dbContext.SaveChanges(h.ctx)).ToNot(HaveOccurred())
+			})
 
-	It("should reflect the updated values", func() {
-		req := queries.GetProject{
-			VirtualServerName: h.VirtualServer(),
-			ProjectSlug:       projectSlug,
-		}
-		project, err := mediatr.Send[*queries.GetProjectResponse](h.Ctx(), h.Mediator(), req)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(project.Name).To(Equal("Updated Name"))
-		Expect(project.Description).To(Equal("Updated Description"))
-	})
-})
+			It("should reflect the updated values", func() {
+				req := queries.GetProject{
+					VirtualServerName: h.VirtualServer(),
+					ProjectSlug:       projectSlug,
+				}
+				project, err := mediatr.Send[*queries.GetProjectResponse](h.Ctx(), h.Mediator(), req)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(project.Name).To(Equal("Updated Name"))
+				Expect(project.Description).To(Equal("Updated Description"))
+			})
+		})
+	}
+}

--- a/tests/integration/resourceserver_flow_test.go
+++ b/tests/integration/resourceserver_flow_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"github.com/The127/Keyline/internal/commands"
+	"github.com/The127/Keyline/internal/config"
 	"github.com/The127/Keyline/internal/queries"
 	"github.com/The127/Keyline/utils"
 
@@ -13,82 +14,92 @@ import (
 	"github.com/onsi/gomega/gstruct"
 )
 
-var _ = Describe("ResourceServer flow", Ordered, func() {
-	var h *harness
+func init() {
+	for _, backend := range testBackends {
+		backend := backend
+		Describe("ResourceServer flow ["+backend.name+"]", Ordered, func() {
+			var h *harness
 
-	projectSlug := "test-project"
-	var resourceServerId uuid.UUID
+			projectSlug := "test-project"
+			var resourceServerId uuid.UUID
 
-	BeforeAll(func() {
-		h = newIntegrationTestHarness()
+			BeforeAll(func() {
+				if backend.dbMode == config.DatabaseModePostgres && !postgresBackendAvailable() {
+					Skip("Postgres not available")
+				}
+				h = newIntegrationTestHarness(backend.dbMode)
 
-		req := commands.CreateProject{
-			VirtualServerName: h.VirtualServer(),
-			Slug:              projectSlug,
-			Name:              "Name",
-			Description:       "Description",
-		}
-		_, err := mediatr.Send[*commands.CreateProjectResponse](h.Ctx(), h.Mediator(), req)
-		Expect(err).ToNot(HaveOccurred())
+				req := commands.CreateProject{
+					VirtualServerName: h.VirtualServer(),
+					Slug:              projectSlug,
+					Name:              "Name",
+					Description:       "Description",
+				}
+				_, err := mediatr.Send[*commands.CreateProjectResponse](h.Ctx(), h.Mediator(), req)
+				Expect(err).ToNot(HaveOccurred())
 
-		Expect(h.dbContext.SaveChanges(h.ctx)).ToNot(HaveOccurred())
-	})
+				Expect(h.dbContext.SaveChanges(h.ctx)).ToNot(HaveOccurred())
+			})
 
-	AfterAll(func() {
-		h.Close()
-	})
+			AfterAll(func() {
+				if h != nil {
+					h.Close()
+				}
+			})
 
-	It("should create a resource server successfully", func() {
-		req := commands.CreateResourceServer{
-			VirtualServerName: h.VirtualServer(),
-			ProjectSlug:       projectSlug,
-			Slug:              "test-resource-server",
-			Name:              "Test Resource Server",
-			Description:       "Description",
-		}
-		response, err := mediatr.Send[*commands.CreateResourceServerResponse](h.Ctx(), h.Mediator(), req)
-		Expect(err).ToNot(HaveOccurred())
-		resourceServerId = response.Id
+			It("should create a resource server successfully", func() {
+				req := commands.CreateResourceServer{
+					VirtualServerName: h.VirtualServer(),
+					ProjectSlug:       projectSlug,
+					Slug:              "test-resource-server",
+					Name:              "Test Resource Server",
+					Description:       "Description",
+				}
+				response, err := mediatr.Send[*commands.CreateResourceServerResponse](h.Ctx(), h.Mediator(), req)
+				Expect(err).ToNot(HaveOccurred())
+				resourceServerId = response.Id
 
-		Expect(h.dbContext.SaveChanges(h.ctx)).ToNot(HaveOccurred())
-	})
+				Expect(h.dbContext.SaveChanges(h.ctx)).ToNot(HaveOccurred())
+			})
 
-	It("should list resource servers successfully", func() {
-		req := queries.ListResourceServers{
-			VirtualServerName: h.VirtualServer(),
-			ProjectSlug:       projectSlug,
-			SearchText:        "test-resource-server",
-		}
-		resp, err := mediatr.Send[*queries.ListResourceServersResponse](h.Ctx(), h.Mediator(), req)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(resp.Items).To(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-			"Id":   Equal(resourceServerId),
-			"Slug": Equal("test-resource-server"),
-			"Name": Equal("Test Resource Server"),
-		})))
-	})
+			It("should list resource servers successfully", func() {
+				req := queries.ListResourceServers{
+					VirtualServerName: h.VirtualServer(),
+					ProjectSlug:       projectSlug,
+					SearchText:        "test-resource-server",
+				}
+				resp, err := mediatr.Send[*queries.ListResourceServersResponse](h.Ctx(), h.Mediator(), req)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resp.Items).To(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+					"Id":   Equal(resourceServerId),
+					"Slug": Equal("test-resource-server"),
+					"Name": Equal("Test Resource Server"),
+				})))
+			})
 
-	It("should edit resource server successfully", func() {
-		req := commands.PatchResourceServer{
-			VirtualServerName: h.VirtualServer(),
-			ProjectSlug:       projectSlug,
-			ResourceServerId:  resourceServerId,
-			Name:              utils.Ptr("Updated Test Resource Server"),
-		}
-		_, err := mediatr.Send[*commands.PatchResourceServerResponse](h.Ctx(), h.Mediator(), req)
-		Expect(err).ToNot(HaveOccurred())
+			It("should edit resource server successfully", func() {
+				req := commands.PatchResourceServer{
+					VirtualServerName: h.VirtualServer(),
+					ProjectSlug:       projectSlug,
+					ResourceServerId:  resourceServerId,
+					Name:              utils.Ptr("Updated Test Resource Server"),
+				}
+				_, err := mediatr.Send[*commands.PatchResourceServerResponse](h.Ctx(), h.Mediator(), req)
+				Expect(err).ToNot(HaveOccurred())
 
-		Expect(h.dbContext.SaveChanges(h.ctx)).ToNot(HaveOccurred())
-	})
+				Expect(h.dbContext.SaveChanges(h.ctx)).ToNot(HaveOccurred())
+			})
 
-	It("should reflect updated values", func() {
-		req := queries.GetResourceServer{
-			VirtualServerName: h.VirtualServer(),
-			ProjectSlug:       projectSlug,
-			ResourceServerId:  resourceServerId,
-		}
-		resp, err := mediatr.Send[*queries.GetResourceServerResponse](h.Ctx(), h.Mediator(), req)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(resp.Name).To(Equal("Updated Test Resource Server"))
-	})
-})
+			It("should reflect updated values", func() {
+				req := queries.GetResourceServer{
+					VirtualServerName: h.VirtualServer(),
+					ProjectSlug:       projectSlug,
+					ResourceServerId:  resourceServerId,
+				}
+				resp, err := mediatr.Send[*queries.GetResourceServerResponse](h.Ctx(), h.Mediator(), req)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resp.Name).To(Equal("Updated Test Resource Server"))
+			})
+		})
+	}
+}

--- a/tests/integration/role_flow_test.go
+++ b/tests/integration/role_flow_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"github.com/The127/Keyline/internal/commands"
+	"github.com/The127/Keyline/internal/config"
 	"github.com/The127/Keyline/internal/queries"
 	"github.com/The127/Keyline/utils"
 
@@ -13,82 +14,92 @@ import (
 	"github.com/onsi/gomega/gstruct"
 )
 
-var _ = Describe("Role flow", Ordered, func() {
-	var h *harness
+func init() {
+	for _, backend := range testBackends {
+		backend := backend
+		Describe("Role flow ["+backend.name+"]", Ordered, func() {
+			var h *harness
 
-	projectSlug := "test-project"
-	var roleId uuid.UUID
+			projectSlug := "test-project"
+			var roleId uuid.UUID
 
-	BeforeAll(func() {
-		h = newIntegrationTestHarness()
+			BeforeAll(func() {
+				if backend.dbMode == config.DatabaseModePostgres && !postgresBackendAvailable() {
+					Skip("Postgres not available")
+				}
+				h = newIntegrationTestHarness(backend.dbMode)
 
-		req := commands.CreateProject{
-			VirtualServerName: h.VirtualServer(),
-			Slug:              projectSlug,
-			Name:              "Name",
-			Description:       "Description",
-		}
-		_, err := mediatr.Send[*commands.CreateProjectResponse](h.Ctx(), h.Mediator(), req)
-		Expect(err).ToNot(HaveOccurred())
+				req := commands.CreateProject{
+					VirtualServerName: h.VirtualServer(),
+					Slug:              projectSlug,
+					Name:              "Name",
+					Description:       "Description",
+				}
+				_, err := mediatr.Send[*commands.CreateProjectResponse](h.Ctx(), h.Mediator(), req)
+				Expect(err).ToNot(HaveOccurred())
 
-		Expect(h.dbContext.SaveChanges(h.ctx)).ToNot(HaveOccurred())
-	})
+				Expect(h.dbContext.SaveChanges(h.ctx)).ToNot(HaveOccurred())
+			})
 
-	AfterAll(func() {
-		h.Close()
-	})
+			AfterAll(func() {
+				if h != nil {
+					h.Close()
+				}
+			})
 
-	It("should create a role successfully", func() {
-		req := commands.CreateRole{
-			VirtualServerName: h.VirtualServer(),
-			ProjectSlug:       projectSlug,
-			Name:              "test-role",
-			Description:       "Description",
-		}
-		response, err := mediatr.Send[*commands.CreateRoleResponse](h.Ctx(), h.Mediator(), req)
-		Expect(err).ToNot(HaveOccurred())
-		roleId = response.Id
+			It("should create a role successfully", func() {
+				req := commands.CreateRole{
+					VirtualServerName: h.VirtualServer(),
+					ProjectSlug:       projectSlug,
+					Name:              "test-role",
+					Description:       "Description",
+				}
+				response, err := mediatr.Send[*commands.CreateRoleResponse](h.Ctx(), h.Mediator(), req)
+				Expect(err).ToNot(HaveOccurred())
+				roleId = response.Id
 
-		Expect(h.dbContext.SaveChanges(h.ctx)).ToNot(HaveOccurred())
-	})
+				Expect(h.dbContext.SaveChanges(h.ctx)).ToNot(HaveOccurred())
+			})
 
-	It("should list roles successfully", func() {
-		req := queries.ListRoles{
-			VirtualServerName: h.VirtualServer(),
-			ProjectSlug:       projectSlug,
-			SearchText:        "test-role",
-		}
-		response, err := mediatr.Send[*queries.ListRolesResponse](h.Ctx(), h.Mediator(), req)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(response.Items).To(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-			"Id":   Equal(roleId),
-			"Name": Equal("test-role"),
-		})))
-	})
+			It("should list roles successfully", func() {
+				req := queries.ListRoles{
+					VirtualServerName: h.VirtualServer(),
+					ProjectSlug:       projectSlug,
+					SearchText:        "test-role",
+				}
+				response, err := mediatr.Send[*queries.ListRolesResponse](h.Ctx(), h.Mediator(), req)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.Items).To(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+					"Id":   Equal(roleId),
+					"Name": Equal("test-role"),
+				})))
+			})
 
-	It("should patch role successfully", func() {
-		cmd := commands.PatchRole{
-			VirtualServerName: h.VirtualServer(),
-			ProjectSlug:       projectSlug,
-			RoleId:            roleId,
-			Name:              utils.Ptr("Updated Name"),
-			Description:       utils.Ptr("Updated Description"),
-		}
-		_, err := mediatr.Send[*commands.PatchRoleResponse](h.Ctx(), h.Mediator(), cmd)
-		Expect(err).ToNot(HaveOccurred())
+			It("should patch role successfully", func() {
+				cmd := commands.PatchRole{
+					VirtualServerName: h.VirtualServer(),
+					ProjectSlug:       projectSlug,
+					RoleId:            roleId,
+					Name:              utils.Ptr("Updated Name"),
+					Description:       utils.Ptr("Updated Description"),
+				}
+				_, err := mediatr.Send[*commands.PatchRoleResponse](h.Ctx(), h.Mediator(), cmd)
+				Expect(err).ToNot(HaveOccurred())
 
-		Expect(h.dbContext.SaveChanges(h.ctx)).ToNot(HaveOccurred())
-	})
+				Expect(h.dbContext.SaveChanges(h.ctx)).ToNot(HaveOccurred())
+			})
 
-	It("should reflect updated values", func() {
-		req := queries.GetRoleQuery{
-			VirtualServerName: h.VirtualServer(),
-			ProjectSlug:       projectSlug,
-			RoleId:            roleId,
-		}
-		resp, err := mediatr.Send[*queries.GetRoleQueryResult](h.Ctx(), h.Mediator(), req)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(resp.Name).To(Equal("Updated Name"))
-		Expect(resp.Description).To(Equal("Updated Description"))
-	})
-})
+			It("should reflect updated values", func() {
+				req := queries.GetRoleQuery{
+					VirtualServerName: h.VirtualServer(),
+					ProjectSlug:       projectSlug,
+					RoleId:            roleId,
+				}
+				resp, err := mediatr.Send[*queries.GetRoleQueryResult](h.Ctx(), h.Mediator(), req)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resp.Name).To(Equal("Updated Name"))
+				Expect(resp.Description).To(Equal("Updated Description"))
+			})
+		})
+	}
+}

--- a/tests/integration/serviceuser_flow_test.go
+++ b/tests/integration/serviceuser_flow_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"github.com/The127/Keyline/internal/commands"
+	"github.com/The127/Keyline/internal/config"
 
 	"github.com/The127/mediatr"
 
@@ -16,51 +17,61 @@ const (
 	ed25519PrivateKey = "-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW\nQyNTUxOQAAACD99cY11g+lad1ap1kvMSs3hbBoWcJ1fzrzxMVQVx42EAAAAIh9iJMufYiT\nLgAAAAtzc2gtZWQyNTUxOQAAACD99cY11g+lad1ap1kvMSs3hbBoWcJ1fzrzxMVQVx42EA\nAAAEDmse+LYEH5FGuuCy9T4UIVFG+isPPii6vXXNtah36Evf31xjXWD6Vp3VqnWS8xKzeF\nsGhZwnV/OvPExVBXHjYQAAAAAAECAwQF\n-----END OPENSSH PRIVATE KEY-----\n"
 )
 
-var _ = Describe("ServiceUser flow", Ordered, func() {
-	var h *harness
-	var serviceUserId uuid.UUID
+func init() {
+	for _, backend := range testBackends {
+		backend := backend
+		Describe("ServiceUser flow ["+backend.name+"]", Ordered, func() {
+			var h *harness
+			var serviceUserId uuid.UUID
 
-	BeforeAll(func() {
-		h = newIntegrationTestHarness()
-	})
+			BeforeAll(func() {
+				if backend.dbMode == config.DatabaseModePostgres && !postgresBackendAvailable() {
+					Skip("Postgres not available")
+				}
+				h = newIntegrationTestHarness(backend.dbMode)
+			})
 
-	AfterAll(func() {
-		h.Close()
-	})
+			AfterAll(func() {
+				if h != nil {
+					h.Close()
+				}
+			})
 
-	It("should create a service user successfully", func() {
-		req := commands.CreateServiceUser{
-			VirtualServerName: h.VirtualServer(),
-			Username:          "service-user",
-		}
-		response, err := mediatr.Send[*commands.CreateServiceUserResponse](h.Ctx(), h.Mediator(), req)
-		Expect(err).ToNot(HaveOccurred())
-		serviceUserId = response.Id
+			It("should create a service user successfully", func() {
+				req := commands.CreateServiceUser{
+					VirtualServerName: h.VirtualServer(),
+					Username:          "service-user",
+				}
+				response, err := mediatr.Send[*commands.CreateServiceUserResponse](h.Ctx(), h.Mediator(), req)
+				Expect(err).ToNot(HaveOccurred())
+				serviceUserId = response.Id
 
-		Expect(h.dbContext.SaveChanges(h.ctx)).ToNot(HaveOccurred())
-	})
+				Expect(h.dbContext.SaveChanges(h.ctx)).ToNot(HaveOccurred())
+			})
 
-	It("should associate public key with service user", func() {
-		req := commands.AssociateServiceUserPublicKey{
-			VirtualServerName: h.VirtualServer(),
-			ServiceUserId:     serviceUserId,
-			PublicKey:         ed25519PublicKey,
-		}
-		_, err := mediatr.Send[*commands.AssociateServiceUserPublicKeyResponse](h.Ctx(), h.Mediator(), req)
-		Expect(err).ToNot(HaveOccurred())
+			It("should associate public key with service user", func() {
+				req := commands.AssociateServiceUserPublicKey{
+					VirtualServerName: h.VirtualServer(),
+					ServiceUserId:     serviceUserId,
+					PublicKey:         ed25519PublicKey,
+				}
+				_, err := mediatr.Send[*commands.AssociateServiceUserPublicKeyResponse](h.Ctx(), h.Mediator(), req)
+				Expect(err).ToNot(HaveOccurred())
 
-		Expect(h.dbContext.SaveChanges(h.ctx)).ToNot(HaveOccurred())
-	})
+				Expect(h.dbContext.SaveChanges(h.ctx)).ToNot(HaveOccurred())
+			})
 
-	It("should remove public key from service user", func() {
-		req := commands.RemoveServiceUserPublicKey{
-			VirtualServerName: h.VirtualServer(),
-			ServiceUserId:     serviceUserId,
-			PublicKey:         ed25519PublicKey,
-		}
-		_, err := mediatr.Send[*commands.RemoveServiceUserPublicKeyResponse](h.Ctx(), h.Mediator(), req)
-		Expect(err).ToNot(HaveOccurred())
+			It("should remove public key from service user", func() {
+				req := commands.RemoveServiceUserPublicKey{
+					VirtualServerName: h.VirtualServer(),
+					ServiceUserId:     serviceUserId,
+					PublicKey:         ed25519PublicKey,
+				}
+				_, err := mediatr.Send[*commands.RemoveServiceUserPublicKeyResponse](h.Ctx(), h.Mediator(), req)
+				Expect(err).ToNot(HaveOccurred())
 
-		Expect(h.dbContext.SaveChanges(h.ctx)).ToNot(HaveOccurred())
-	})
-})
+				Expect(h.dbContext.SaveChanges(h.ctx)).ToNot(HaveOccurred())
+			})
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `database.mode: memory` config option
- Implements full in-memory backend mirroring the postgres backend
- No external dependencies required — useful for e2e and integration tests

## Test plan
- [ ] `go build ./...` passes
- [ ] Keyline starts with `database.mode: memory`
- [ ] e2e tests pass without Postgres