### PR TITLE
fix: build binary to unambiguous path in Containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -15,7 +15,7 @@ RUN go mod download
 COPY . .
 
 # Build binary
-RUN go build -o api ./cmd/api
+RUN go build -o /bin/api ./cmd/api
 
 # ---- Runtime stage ----
 FROM alpine:3.22.1 AS runtime
@@ -23,7 +23,7 @@ FROM alpine:3.22.1 AS runtime
 WORKDIR /app
 
 # Copy binary from builder
-COPY --from=builder /app/api /app/api
+COPY --from=builder /bin/api /app/api
 
 # Expose port (adjust if needed)
 EXPOSE 8080


### PR DESCRIPTION
## Summary
- `go build -o api ./cmd/api` with `WORKDIR /app` and `COPY . .` places the binary at `/app/api/api` instead of `/app/api` because the `api/` source directory already exists at that path
- Fixed by building to `/bin/api` in the builder stage and copying from there to `/app/api` in the runtime stage
- `CMD ["/app/api"]` is now correct again

## Root cause
When `-o` points to an existing directory, `go build` places the binary inside it named after the package, not at the path itself.