### PR TITLE
fix: client and routing bug fixes

### DIFF
--- a/client/serviceusertokensource.go
+++ b/client/serviceusertokensource.go
@@ -59,7 +59,8 @@ func (s *ServiceUserTokenSource) Token() (*oauth2.Token, error) {
 		return nil, fmt.Errorf("signing JWT: %w", err)
 	}
 
-	resp, err := http.PostForm(
+	httpClient := &http.Client{Timeout: 10 * time.Second}
+	resp, err := httpClient.PostForm(
 		fmt.Sprintf("%s/oidc/%s/token", s.KeylineURL, s.VirtualServer),
 		url.Values{
 			"grant_type":         {"urn:ietf:params:oauth:grant-type:token-exchange"},

--- a/client/transport.go
+++ b/client/transport.go
@@ -55,7 +55,7 @@ func NewTransport(baseUrl string, virtualServer string, options ...TransportOpti
 	transport := &Transport{
 		baseURL:       baseUrl,
 		virtualServer: virtualServer,
-		client:        http.DefaultClient,
+		client:        &http.Client{Transport: http.DefaultTransport},
 	}
 
 	for _, option := range options {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -157,7 +157,7 @@ func mapApiRoutes(r *mux.Router) {
 	vsApiRouter.HandleFunc("", handlers.GetVirtualServer).Methods(http.MethodGet, http.MethodOptions)
 	vsApiRouter.HandleFunc("/public-info", handlers.GetVirtualServerPublicInfo).Methods(http.MethodGet, http.MethodOptions)
 	vsApiRouter.HandleFunc("/health", handlers.VirtualServerHealth).Methods(http.MethodGet, http.MethodOptions)
-	vsApiRouter.HandleFunc("/", handlers.PatchVirtualServer).Methods(http.MethodPatch, http.MethodOptions)
+	vsApiRouter.HandleFunc("", handlers.PatchVirtualServer).Methods(http.MethodPatch, http.MethodOptions)
 
 	vsApiRouter.HandleFunc("/password-policies/rules", handlers.ListPasswordRules).Methods(http.MethodGet, http.MethodOptions)
 	vsApiRouter.HandleFunc("/password-policies/rules/{ruleType}", handlers.CreatePasswordRule).Methods(http.MethodPost, http.MethodOptions)


### PR DESCRIPTION
## Summary
- Register PATCH virtual server route without trailing slash
- Use owned `http.Client` in `NewTransport` to avoid nil Transport panic
- Add 10s timeout to `ServiceUserTokenSource` HTTP client