### PR TITLE
refactor: nest ApplicationClient under ProjectClient

### DIFF
--- a/client/application.go
+++ b/client/application.go
@@ -25,18 +25,20 @@ type ApplicationClient interface {
 	Delete(ctx context.Context, id uuid.UUID) error
 }
 
-func NewApplicationClient(transport *Transport) ApplicationClient {
+func NewApplicationClient(transport *Transport, projectSlug string) ApplicationClient {
 	return &application{
-		transport: transport,
+		transport:   transport,
+		projectSlug: projectSlug,
 	}
 }
 
 type application struct {
-	transport *Transport
+	transport   *Transport
+	projectSlug string
 }
 
 func (a *application) Create(ctx context.Context, dto api.CreateApplicationRequestDto) (api.CreateApplicationResponseDto, error) {
-	endpoint := "/applications"
+	endpoint := fmt.Sprintf("/projects/%s/applications", a.projectSlug)
 
 	jsonBytes, err := json.Marshal(dto)
 	if err != nil {
@@ -68,7 +70,7 @@ func (a *application) List(ctx context.Context, params ListApplicationParams) (a
 	values.Add("page", fmt.Sprintf("%d", params.Page))
 	values.Add("size", fmt.Sprintf("%d", params.Size))
 
-	endpoint := fmt.Sprintf("/applications?%s", values.Encode())
+	endpoint := fmt.Sprintf("/projects/%s/applications?%s", a.projectSlug, values.Encode())
 
 	request, err := a.transport.NewTenantRequest(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
@@ -91,7 +93,7 @@ func (a *application) List(ctx context.Context, params ListApplicationParams) (a
 }
 
 func (a *application) Get(ctx context.Context, id uuid.UUID) (api.GetApplicationResponseDto, error) {
-	endpoint := fmt.Sprintf("/applications/%s", id.String())
+	endpoint := fmt.Sprintf("/projects/%s/applications/%s", a.projectSlug, id.String())
 
 	request, err := a.transport.NewTenantRequest(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
@@ -114,7 +116,7 @@ func (a *application) Get(ctx context.Context, id uuid.UUID) (api.GetApplication
 }
 
 func (a *application) Delete(ctx context.Context, id uuid.UUID) error {
-	endpoint := fmt.Sprintf("/applications/%s", id.String())
+	endpoint := fmt.Sprintf("/projects/%s/applications/%s", a.projectSlug, id.String())
 
 	request, err := a.transport.NewTenantRequest(ctx, http.MethodDelete, endpoint, nil)
 	if err != nil {
@@ -131,7 +133,7 @@ func (a *application) Delete(ctx context.Context, id uuid.UUID) error {
 }
 
 func (a *application) Patch(ctx context.Context, id uuid.UUID, dto api.PatchApplicationRequestDto) error {
-	endpoint := fmt.Sprintf("/applications/%s", id.String())
+	endpoint := fmt.Sprintf("/projects/%s/applications/%s", a.projectSlug, id.String())
 
 	jsonBytes, err := json.Marshal(dto)
 	if err != nil {

--- a/client/application_test.go
+++ b/client/application_test.go
@@ -1,14 +1,14 @@
 package client
 
 import (
-	"github.com/The127/Keyline/api"
-	"github.com/The127/Keyline/utils"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/The127/Keyline/api"
+	"github.com/The127/Keyline/utils"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
 )
@@ -39,7 +39,7 @@ func (s *ApplicationClientSuite) TestCreateApplication_HappyPath() {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		s.Equal(http.MethodPost, r.Method)
-		s.Equal("/api/virtual-servers/test/applications", r.URL.Path)
+		s.Equal("/api/virtual-servers/test/projects/my-project/applications", r.URL.Path)
 
 		var requestDto api.CreateApplicationRequestDto
 		err := json.NewDecoder(r.Body).Decode(&requestDto)
@@ -51,7 +51,7 @@ func (s *ApplicationClientSuite) TestCreateApplication_HappyPath() {
 	}))
 	defer server.Close()
 
-	testee := NewClient(server.URL, "test").Application()
+	testee := NewClient(server.URL, "test").Project().Application("my-project")
 
 	// act
 	responseDto, err := testee.Create(s.T().Context(), request)
@@ -88,14 +88,14 @@ func (s *ApplicationClientSuite) TestListApplications_HappyPath() {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		s.Equal(http.MethodGet, r.Method)
-		s.Equal("/api/virtual-servers/test/applications", r.URL.Path)
+		s.Equal("/api/virtual-servers/test/projects/my-project/applications", r.URL.Path)
 
 		err := json.NewEncoder(w).Encode(response)
 		s.NoError(err)
 	}))
 	defer server.Close()
 
-	testee := NewClient(server.URL, "test").Application()
+	testee := NewClient(server.URL, "test").Project().Application("my-project")
 
 	// act
 	responseDto, err := testee.List(s.T().Context(), requestParams)
@@ -119,14 +119,14 @@ func (s *ApplicationClientSuite) TestGetApplication_HappyPath() {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		s.Equal(http.MethodGet, r.Method)
-		s.Equal(fmt.Sprintf("/api/virtual-servers/test/applications/%s", requestId), r.URL.Path)
+		s.Equal(fmt.Sprintf("/api/virtual-servers/test/projects/my-project/applications/%s", requestId), r.URL.Path)
 
 		err := json.NewEncoder(w).Encode(response)
 		s.NoError(err)
 	}))
 	defer server.Close()
 
-	testee := NewClient(server.URL, "test").Application()
+	testee := NewClient(server.URL, "test").Project().Application("my-project")
 
 	// act
 	responseDto, err := testee.Get(s.T().Context(), requestId)
@@ -142,11 +142,11 @@ func (s *ApplicationClientSuite) TestDeleteApplication_HappyPath() {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		s.Equal(http.MethodDelete, r.Method)
-		s.Equal(fmt.Sprintf("/api/virtual-servers/test/applications/%s", requestId), r.URL.Path)
+		s.Equal(fmt.Sprintf("/api/virtual-servers/test/projects/my-project/applications/%s", requestId), r.URL.Path)
 	}))
 	defer server.Close()
 
-	testee := NewClient(server.URL, "test").Application()
+	testee := NewClient(server.URL, "test").Project().Application("my-project")
 
 	// act
 	err := testee.Delete(s.T().Context(), requestId)
@@ -165,7 +165,7 @@ func (s *ApplicationClientSuite) TestPatchApplication_HappyPath() {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		s.Equal(http.MethodPatch, r.Method)
-		s.Equal(fmt.Sprintf("/api/virtual-servers/test/applications/%s", requestId), r.URL.Path)
+		s.Equal(fmt.Sprintf("/api/virtual-servers/test/projects/my-project/applications/%s", requestId), r.URL.Path)
 
 		var requestDto api.PatchApplicationRequestDto
 		err := json.NewDecoder(r.Body).Decode(&requestDto)
@@ -176,7 +176,7 @@ func (s *ApplicationClientSuite) TestPatchApplication_HappyPath() {
 	}))
 	defer server.Close()
 
-	testee := NewClient(server.URL, "test").Application()
+	testee := NewClient(server.URL, "test").Project().Application("my-project")
 
 	// act
 	err := testee.Patch(s.T().Context(), requestId, request)

--- a/client/client.go
+++ b/client/client.go
@@ -1,7 +1,6 @@
 package client
 
 type Client interface {
-	Application() ApplicationClient
 	VirtualServer() VirtualServerClient
 	User() UserClient
 	Oidc() OidcClient
@@ -16,10 +15,6 @@ func NewClient(baseUrl string, virtualServer string, opts ...TransportOptions) C
 	return &client{
 		transport: NewTransport(baseUrl, virtualServer, opts...),
 	}
-}
-
-func (c *client) Application() ApplicationClient {
-	return NewApplicationClient(c.transport)
 }
 
 func (c *client) VirtualServer() VirtualServerClient {

--- a/client/project.go
+++ b/client/project.go
@@ -13,6 +13,7 @@ import (
 type ProjectClient interface {
 	Create(ctx context.Context, input api.CreateProjectRequestDto) (api.CreateProjectResponseDto, error)
 	Get(ctx context.Context, slug string) (api.GetProjectResponseDto, error)
+	Application(projectSlug string) ApplicationClient
 }
 
 func NewProjectClient(transport *Transport) ProjectClient {
@@ -46,6 +47,10 @@ func (c *projectClient) Create(ctx context.Context, input api.CreateProjectReque
 	}
 
 	return responseDto, nil
+}
+
+func (c *projectClient) Application(projectSlug string) ApplicationClient {
+	return NewApplicationClient(c.transport, projectSlug)
 }
 
 func (c *projectClient) Get(ctx context.Context, slug string) (api.GetProjectResponseDto, error) {


### PR DESCRIPTION
## Summary
- `ApplicationClient` is now accessed via `kc.Project().Application("slug")` instead of `kc.Application()`
- All application endpoints updated from `/applications/...` to `/projects/{slug}/applications/...`
- Removes `Application()` from the top-level `Client` interface