### PR TITLE
feat: add role client, PatchRole and DeleteRole endpoints

### DIFF
--- a/api/roles.go
+++ b/api/roles.go
@@ -33,6 +33,11 @@ type CreateRoleResponseDto struct {
 	Id uuid.UUID `json:"id"`
 }
 
+type PatchRoleRequestDto struct {
+	Name        *string `json:"name,omitempty"`
+	Description *string `json:"description,omitempty"`
+}
+
 type AssignRoleRequestDto struct {
 	UserId uuid.UUID `json:"userId" validate:"required,uuid=4"`
 }

--- a/client/project.go
+++ b/client/project.go
@@ -14,6 +14,7 @@ type ProjectClient interface {
 	Create(ctx context.Context, input api.CreateProjectRequestDto) (api.CreateProjectResponseDto, error)
 	Get(ctx context.Context, slug string) (api.GetProjectResponseDto, error)
 	Application(projectSlug string) ApplicationClient
+	Role(projectSlug string) RoleClient
 }
 
 func NewProjectClient(transport *Transport) ProjectClient {
@@ -51,6 +52,10 @@ func (c *projectClient) Create(ctx context.Context, input api.CreateProjectReque
 
 func (c *projectClient) Application(projectSlug string) ApplicationClient {
 	return NewApplicationClient(c.transport, projectSlug)
+}
+
+func (c *projectClient) Role(projectSlug string) RoleClient {
+	return NewRoleClient(c.transport, projectSlug)
 }
 
 func (c *projectClient) Get(ctx context.Context, slug string) (api.GetProjectResponseDto, error) {

--- a/client/role.go
+++ b/client/role.go
@@ -1,0 +1,152 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/The127/Keyline/api"
+	"github.com/google/uuid"
+)
+
+type ListRoleParams struct {
+	Page int
+	Size int
+}
+
+type RoleClient interface {
+	Create(ctx context.Context, dto api.CreateRoleRequestDto) (api.CreateRoleResponseDto, error)
+	List(ctx context.Context, params ListRoleParams) (api.PagedRolesResponseDto, error)
+	Get(ctx context.Context, id uuid.UUID) (api.GetRoleByIdResponseDto, error)
+	Patch(ctx context.Context, id uuid.UUID, dto api.PatchRoleRequestDto) error
+	Delete(ctx context.Context, id uuid.UUID) error
+}
+
+func NewRoleClient(transport *Transport, projectSlug string) RoleClient {
+	return &roleClient{
+		transport:   transport,
+		projectSlug: projectSlug,
+	}
+}
+
+type roleClient struct {
+	transport   *Transport
+	projectSlug string
+}
+
+func (c *roleClient) Create(ctx context.Context, dto api.CreateRoleRequestDto) (api.CreateRoleResponseDto, error) {
+	endpoint := fmt.Sprintf("/projects/%s/roles", c.projectSlug)
+
+	jsonBytes, err := json.Marshal(dto)
+	if err != nil {
+		return api.CreateRoleResponseDto{}, fmt.Errorf("marshaling dto: %w", err)
+	}
+
+	request, err := c.transport.NewTenantRequest(ctx, http.MethodPost, endpoint, bytes.NewBuffer(jsonBytes))
+	if err != nil {
+		return api.CreateRoleResponseDto{}, fmt.Errorf("creating request: %w", err)
+	}
+
+	response, err := c.transport.Do(request)
+	if err != nil {
+		return api.CreateRoleResponseDto{}, fmt.Errorf("doing request: %w", err)
+	}
+	defer response.Body.Close() //nolint:errcheck
+
+	var responseDto api.CreateRoleResponseDto
+	if err := json.NewDecoder(response.Body).Decode(&responseDto); err != nil {
+		return api.CreateRoleResponseDto{}, fmt.Errorf("decoding response: %w", err)
+	}
+
+	return responseDto, nil
+}
+
+func (c *roleClient) List(ctx context.Context, params ListRoleParams) (api.PagedRolesResponseDto, error) {
+	values := url.Values{}
+	values.Add("page", fmt.Sprintf("%d", params.Page))
+	values.Add("size", fmt.Sprintf("%d", params.Size))
+
+	endpoint := fmt.Sprintf("/projects/%s/roles?%s", c.projectSlug, values.Encode())
+
+	request, err := c.transport.NewTenantRequest(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return api.PagedRolesResponseDto{}, fmt.Errorf("creating request: %w", err)
+	}
+
+	response, err := c.transport.Do(request)
+	if err != nil {
+		return api.PagedRolesResponseDto{}, fmt.Errorf("doing request: %w", err)
+	}
+	defer response.Body.Close() //nolint:errcheck
+
+	var responseDto api.PagedRolesResponseDto
+	if err := json.NewDecoder(response.Body).Decode(&responseDto); err != nil {
+		return api.PagedRolesResponseDto{}, fmt.Errorf("decoding response: %w", err)
+	}
+
+	return responseDto, nil
+}
+
+func (c *roleClient) Get(ctx context.Context, id uuid.UUID) (api.GetRoleByIdResponseDto, error) {
+	endpoint := fmt.Sprintf("/projects/%s/roles/%s", c.projectSlug, id.String())
+
+	request, err := c.transport.NewTenantRequest(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return api.GetRoleByIdResponseDto{}, fmt.Errorf("creating request: %w", err)
+	}
+
+	response, err := c.transport.Do(request)
+	if err != nil {
+		return api.GetRoleByIdResponseDto{}, fmt.Errorf("doing request: %w", err)
+	}
+	defer response.Body.Close() //nolint:errcheck
+
+	var responseDto api.GetRoleByIdResponseDto
+	if err := json.NewDecoder(response.Body).Decode(&responseDto); err != nil {
+		return api.GetRoleByIdResponseDto{}, fmt.Errorf("decoding response: %w", err)
+	}
+
+	return responseDto, nil
+}
+
+func (c *roleClient) Patch(ctx context.Context, id uuid.UUID, dto api.PatchRoleRequestDto) error {
+	endpoint := fmt.Sprintf("/projects/%s/roles/%s", c.projectSlug, id.String())
+
+	jsonBytes, err := json.Marshal(dto)
+	if err != nil {
+		return fmt.Errorf("marshaling dto: %w", err)
+	}
+
+	request, err := c.transport.NewTenantRequest(ctx, http.MethodPatch, endpoint, bytes.NewBuffer(jsonBytes))
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+
+	response, err := c.transport.Do(request)
+	if err != nil {
+		return fmt.Errorf("doing request: %w", err)
+	}
+	defer response.Body.Close() //nolint:errcheck
+
+	return nil
+}
+
+func (c *roleClient) Delete(ctx context.Context, id uuid.UUID) error {
+	endpoint := fmt.Sprintf("/projects/%s/roles/%s", c.projectSlug, id.String())
+
+	request, err := c.transport.NewTenantRequest(ctx, http.MethodDelete, endpoint, nil)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+
+	response, err := c.transport.Do(request)
+	if err != nil {
+		return fmt.Errorf("doing request: %w", err)
+	}
+	defer response.Body.Close() //nolint:errcheck
+
+	return nil
+}

--- a/internal/authentication/permissions/permissions.go
+++ b/internal/authentication/permissions/permissions.go
@@ -16,6 +16,7 @@ const (
 
 	RoleCreate Permission = "role:create"
 	RoleUpdate Permission = "role:update"
+	RoleDelete Permission = "role:delete"
 	RoleAssign Permission = "role:assign"
 	RoleView   Permission = "role:view"
 

--- a/internal/commands/DeleteRole.go
+++ b/internal/commands/DeleteRole.go
@@ -1,0 +1,75 @@
+package commands
+
+import (
+	"github.com/The127/Keyline/internal/authentication/permissions"
+	"github.com/The127/Keyline/internal/behaviours"
+	"github.com/The127/Keyline/internal/database"
+	"github.com/The127/Keyline/internal/middlewares"
+	"github.com/The127/Keyline/internal/repositories"
+	"context"
+	"fmt"
+
+	"github.com/The127/ioc"
+
+	"github.com/google/uuid"
+)
+
+type DeleteRole struct {
+	VirtualServerName string
+	ProjectSlug       string
+	RoleId            uuid.UUID
+}
+
+func (a DeleteRole) LogRequest() bool {
+	return true
+}
+
+func (a DeleteRole) LogResponse() bool {
+	return true
+}
+
+func (a DeleteRole) IsAllowed(ctx context.Context) (behaviours.PolicyResult, error) {
+	return behaviours.PermissionBasedPolicy(ctx, permissions.RoleDelete)
+}
+
+func (a DeleteRole) GetRequestName() string {
+	return "DeleteRole"
+}
+
+type DeleteRoleResponse struct{}
+
+func HandleDeleteRole(ctx context.Context, command DeleteRole) (*DeleteRoleResponse, error) {
+	scope := middlewares.GetScope(ctx)
+	dbContext := ioc.GetDependency[database.Context](scope)
+
+	virtualServerFilter := repositories.NewVirtualServerFilter().Name(command.VirtualServerName)
+	virtualServer, err := dbContext.VirtualServers().FirstOrErr(ctx, virtualServerFilter)
+	if err != nil {
+		return nil, fmt.Errorf("getting virtual server: %w", err)
+	}
+
+	projectFilter := repositories.NewProjectFilter().
+		VirtualServerId(virtualServer.Id()).
+		Slug(command.ProjectSlug)
+	project, err := dbContext.Projects().FirstOrErr(ctx, projectFilter)
+	if err != nil {
+		return nil, fmt.Errorf("getting project: %w", err)
+	}
+
+	roleFilter := repositories.NewRoleFilter().
+		VirtualServerId(virtualServer.Id()).
+		ProjectId(project.Id()).
+		Id(command.RoleId)
+	role, err := dbContext.Roles().FirstOrNil(ctx, roleFilter)
+	if err != nil {
+		return nil, fmt.Errorf("getting role: %w", err)
+	}
+
+	if role == nil {
+		return &DeleteRoleResponse{}, nil
+	}
+
+	dbContext.Roles().Delete(role.Id())
+
+	return &DeleteRoleResponse{}, nil
+}

--- a/internal/handlers/roles.go
+++ b/internal/handlers/roles.go
@@ -350,3 +350,107 @@ func ListUsersInRole(w http.ResponseWriter, r *http.Request) {
 		utils.HandleHttpError(w, err)
 	}
 }
+
+// PatchRole updates fields of a specific role by ID
+// @Summary Patch role
+// @Description Update a role by ID within a project
+// @Tags Roles
+// @Accept json
+// @Param virtualServerName path string true "Virtual server name" default(keyline)
+// @Param projectSlug path string true "Project slug"
+// @Param roleId path string true "Role ID (UUID)"
+// @Param request body PatchRoleRequestDto true "Role data"
+// @Security BearerAuth
+// @Success 204 {string} string "No Content"
+// @Failure 400
+// @Failure 404 "Role not found"
+// @Router /api/virtual-servers/{virtualServerName}/projects/{projectSlug}/roles/{roleId} [patch]
+func PatchRole(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	vsName, err := middlewares.GetVirtualServerName(ctx)
+	if err != nil {
+		utils.HandleHttpError(w, err)
+		return
+	}
+
+	vars := mux.Vars(r)
+	projectSlug := vars["projectSlug"]
+
+	roleIdString := vars["roleId"]
+	roleId, err := uuid.Parse(roleIdString)
+	if err != nil {
+		utils.HandleHttpError(w, utils.ErrInvalidUuid)
+		return
+	}
+
+	var dto api.PatchRoleRequestDto
+	err = json.NewDecoder(r.Body).Decode(&dto)
+	if err != nil {
+		utils.HandleHttpError(w, err)
+		return
+	}
+
+	scope := middlewares.GetScope(ctx)
+	m := ioc.GetDependency[mediatr.Mediator](scope)
+
+	_, err = mediatr.Send[*commands.PatchRoleResponse](ctx, m, commands.PatchRole{
+		VirtualServerName: vsName,
+		ProjectSlug:       projectSlug,
+		RoleId:            roleId,
+		Name:              dto.Name,
+		Description:       dto.Description,
+	})
+	if err != nil {
+		utils.HandleHttpError(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// DeleteRole deletes a specific role by ID
+// @Summary Delete role
+// @Description Delete a role by ID from a project
+// @Tags Roles
+// @Param virtualServerName path string true "Virtual server name" default(keyline)
+// @Param projectSlug path string true "Project slug"
+// @Param roleId path string true "Role ID (UUID)"
+// @Security BearerAuth
+// @Success 204 {string} string "No Content"
+// @Failure 400
+// @Router /api/virtual-servers/{virtualServerName}/projects/{projectSlug}/roles/{roleId} [delete]
+func DeleteRole(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	vsName, err := middlewares.GetVirtualServerName(ctx)
+	if err != nil {
+		utils.HandleHttpError(w, err)
+		return
+	}
+
+	vars := mux.Vars(r)
+	projectSlug := vars["projectSlug"]
+
+	roleIdString := vars["roleId"]
+	roleId, err := uuid.Parse(roleIdString)
+	if err != nil {
+		utils.HandleHttpError(w, utils.ErrInvalidUuid)
+		return
+	}
+
+	scope := middlewares.GetScope(ctx)
+	m := ioc.GetDependency[mediatr.Mediator](scope)
+
+	_, err = mediatr.Send[*commands.DeleteRoleResponse](ctx, m, commands.DeleteRole{
+		VirtualServerName: vsName,
+		ProjectSlug:       projectSlug,
+		RoleId:            roleId,
+	})
+	if err != nil {
+		utils.HandleHttpError(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -194,6 +194,8 @@ func mapApiRoutes(r *mux.Router) {
 	vsApiRouter.HandleFunc("/projects/{projectSlug}/roles", handlers.CreateRole).Methods(http.MethodPost, http.MethodOptions)
 	vsApiRouter.HandleFunc("/projects/{projectSlug}/roles", handlers.ListRoles).Methods(http.MethodGet, http.MethodOptions)
 	vsApiRouter.HandleFunc("/projects/{projectSlug}/roles/{roleId}", handlers.GetRoleById).Methods(http.MethodGet, http.MethodOptions)
+	vsApiRouter.HandleFunc("/projects/{projectSlug}/roles/{roleId}", handlers.PatchRole).Methods(http.MethodPatch, http.MethodOptions)
+	vsApiRouter.HandleFunc("/projects/{projectSlug}/roles/{roleId}", handlers.DeleteRole).Methods(http.MethodDelete, http.MethodOptions)
 	vsApiRouter.HandleFunc("/projects/{projectSlug}/roles/{roleId}/assign", handlers.AssignRole).Methods(http.MethodPost, http.MethodOptions)
 	vsApiRouter.HandleFunc("/projects/{projectSlug}/roles/{roleId}/users", handlers.ListUsersInRole).Methods(http.MethodGet, http.MethodOptions)
 

--- a/internal/setup/mediator.go
+++ b/internal/setup/mediator.go
@@ -67,6 +67,7 @@ func Mediator(dc *ioc.DependencyCollection) {
 	mediatr.RegisterHandler(m, queries.HandleGetRole)
 	mediatr.RegisterHandler(m, commands.HandleCreateRole)
 	mediatr.RegisterHandler(m, commands.HandlePatchRole)
+	mediatr.RegisterHandler(m, commands.HandleDeleteRole)
 	mediatr.RegisterHandler(m, commands.HandleAssignRoleToUser)
 	mediatr.RegisterHandler(m, queries.HandleListUsersInRole)
 


### PR DESCRIPTION
## Summary
- Add `PatchRoleRequestDto` to api/roles.go
- Add `PatchRole` and `DeleteRole` HTTP handlers and routes
- Add `RoleDelete` permission constant and `DeleteRole` command
- Add `role.go` client with Create, List, Get, Patch, Delete
- Wire `Role(projectSlug)` into `ProjectClient`

## Test plan
- [ ] PATCH /projects/{slug}/roles/{id} returns 204
- [ ] DELETE /projects/{slug}/roles/{id} returns 204
- [ ] RoleClient works end-to-end via operator e2e