### PR TITLE
feat: honor system:system-admin tokens from the initial VS across all virtual servers

### DIFF
--- a/client/role.go
+++ b/client/role.go
@@ -17,12 +17,19 @@ type ListRoleParams struct {
 	Size int
 }
 
+type ListUsersInRoleParams struct {
+	Page int
+	Size int
+}
+
 type RoleClient interface {
 	Create(ctx context.Context, dto api.CreateRoleRequestDto) (api.CreateRoleResponseDto, error)
 	List(ctx context.Context, params ListRoleParams) (api.PagedRolesResponseDto, error)
 	Get(ctx context.Context, id uuid.UUID) (api.GetRoleByIdResponseDto, error)
 	Patch(ctx context.Context, id uuid.UUID, dto api.PatchRoleRequestDto) error
 	Delete(ctx context.Context, id uuid.UUID) error
+	Assign(ctx context.Context, roleId uuid.UUID, userId uuid.UUID) error
+	ListUsers(ctx context.Context, roleId uuid.UUID, params ListUsersInRoleParams) (api.PagedUsersInRoleResponseDto, error)
 }
 
 func NewRoleClient(transport *Transport, projectSlug string) RoleClient {
@@ -149,4 +156,53 @@ func (c *roleClient) Delete(ctx context.Context, id uuid.UUID) error {
 	defer response.Body.Close() //nolint:errcheck
 
 	return nil
+}
+
+func (c *roleClient) Assign(ctx context.Context, roleId uuid.UUID, userId uuid.UUID) error {
+	endpoint := fmt.Sprintf("/projects/%s/roles/%s/assign", c.projectSlug, roleId.String())
+
+	dto := api.AssignRoleRequestDto{UserId: userId}
+	jsonBytes, err := json.Marshal(dto)
+	if err != nil {
+		return fmt.Errorf("marshaling dto: %w", err)
+	}
+
+	request, err := c.transport.NewTenantRequest(ctx, http.MethodPost, endpoint, bytes.NewBuffer(jsonBytes))
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+
+	response, err := c.transport.Do(request)
+	if err != nil {
+		return fmt.Errorf("doing request: %w", err)
+	}
+	defer response.Body.Close() //nolint:errcheck
+
+	return nil
+}
+
+func (c *roleClient) ListUsers(ctx context.Context, roleId uuid.UUID, params ListUsersInRoleParams) (api.PagedUsersInRoleResponseDto, error) {
+	values := url.Values{}
+	values.Add("page", fmt.Sprintf("%d", params.Page))
+	values.Add("size", fmt.Sprintf("%d", params.Size))
+
+	endpoint := fmt.Sprintf("/projects/%s/roles/%s/users?%s", c.projectSlug, roleId.String(), values.Encode())
+
+	request, err := c.transport.NewTenantRequest(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return api.PagedUsersInRoleResponseDto{}, fmt.Errorf("creating request: %w", err)
+	}
+
+	response, err := c.transport.Do(request)
+	if err != nil {
+		return api.PagedUsersInRoleResponseDto{}, fmt.Errorf("doing request: %w", err)
+	}
+	defer response.Body.Close() //nolint:errcheck
+
+	var responseDto api.PagedUsersInRoleResponseDto
+	if err := json.NewDecoder(response.Body).Decode(&responseDto); err != nil {
+		return api.PagedUsersInRoleResponseDto{}, fmt.Errorf("decoding response: %w", err)
+	}
+
+	return responseDto, nil
 }

--- a/internal/authentication/AuthenticationMiddleware.go
+++ b/internal/authentication/AuthenticationMiddleware.go
@@ -107,14 +107,12 @@ func extractUserFromBearerToken(ctx context.Context, authorizationHeader string,
 
 	keyService := ioc.GetDependency[services.KeyService](scope)
 
-	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (any, error) {
-		// TODO: use the key id to get the key and refactor key infrastructure
-		keyPair, err := keyService.GetKey(vsName, config.SigningAlgorithm(token.Header["alg"].(string)))
-		if err != nil {
-			return nil, err
-		}
-		return keyPair.PublicKey(), nil
-	})
+	// TODO: use the key id to get the key and refactor key infrastructure
+	token, err := parseTokenWithVS(tokenString, keyService, vsName)
+	if err != nil && vsName != config.C.InitialVirtualServer.Name {
+		// system:system-admin tokens are issued by the initial VS and must work across all VSes
+		token, err = parseTokenWithVS(tokenString, keyService, config.C.InitialVirtualServer.Name)
+	}
 	if err != nil {
 		return CurrentUser{}, fmt.Errorf("parsing token [%s]: %w", err.Error(), utils.ErrHttpUnauthorized)
 	}
@@ -194,4 +192,14 @@ func SystemUser() CurrentUser {
 	user := NewCurrentUser(uuid.Nil)
 	assignPermissionsToUser(&user, roles.SystemUser)
 	return user
+}
+
+func parseTokenWithVS(tokenString string, keyService services.KeyService, vsName string) (*jwt.Token, error) {
+	return jwt.Parse(tokenString, func(token *jwt.Token) (any, error) {
+		keyPair, err := keyService.GetKey(vsName, config.SigningAlgorithm(token.Header["alg"].(string)))
+		if err != nil {
+			return nil, err
+		}
+		return keyPair.PublicKey(), nil
+	})
 }

--- a/internal/authentication/AuthenticationMiddleware.go
+++ b/internal/authentication/AuthenticationMiddleware.go
@@ -109,7 +109,10 @@ func extractUserFromBearerToken(ctx context.Context, authorizationHeader string,
 
 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (any, error) {
 		// TODO: use the key id to get the key and refactor key infrastructure
-		keyPair := keyService.GetKey(vsName, config.SigningAlgorithm(token.Header["alg"].(string)))
+		keyPair, err := keyService.GetKey(vsName, config.SigningAlgorithm(token.Header["alg"].(string)))
+		if err != nil {
+			return nil, err
+		}
 		return keyPair.PublicKey(), nil
 	})
 	if err != nil {

--- a/internal/handlers/oidc.go
+++ b/internal/handlers/oidc.go
@@ -115,7 +115,11 @@ func WellKnownJwks(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	keyPair := keyService.GetKey(vsName, virtualServer.SigningAlgorithm())
+	keyPair, err := keyService.GetKey(vsName, virtualServer.SigningAlgorithm())
+	if err != nil {
+		utils.HandleHttpError(w, err)
+		return
+	}
 
 	kid := keyPair.GetKid()
 
@@ -537,7 +541,11 @@ func OidcEndSession(w http.ResponseWriter, r *http.Request) {
 	}
 
 	keyService := ioc.GetDependency[services.KeyService](scope)
-	keyPair := keyService.GetKey(vsName, virtualServer.SigningAlgorithm())
+	keyPair, err := keyService.GetKey(vsName, virtualServer.SigningAlgorithm())
+	if err != nil {
+		utils.HandleHttpError(w, err)
+		return
+	}
 
 	idTokenString := r.Form.Get("id_token_hint")
 	if idTokenString == "" {
@@ -685,7 +693,11 @@ func OidcUserinfo(w http.ResponseWriter, r *http.Request) {
 	}
 
 	keyService := ioc.GetDependency[services.KeyService](scope)
-	keyPair := keyService.GetKey(vsName, virtualServer.SigningAlgorithm())
+	keyPair, err := keyService.GetKey(vsName, virtualServer.SigningAlgorithm())
+	if err != nil {
+		utils.HandleHttpError(w, err)
+		return
+	}
 
 	err = r.ParseForm()
 	if err != nil {
@@ -964,7 +976,11 @@ func handleAuthorizationCode(w http.ResponseWriter, r *http.Request) {
 	}
 
 	keyService := ioc.GetDependency[services.KeyService](scope)
-	keyPair := keyService.GetKey(codeInfo.VirtualServerName, virtualServer.SigningAlgorithm())
+	keyPair, err := keyService.GetKey(codeInfo.VirtualServerName, virtualServer.SigningAlgorithm())
+	if err != nil {
+		utils.HandleHttpError(w, err)
+		return
+	}
 
 	tokenDuration := time.Hour // TODO: make this configurable per virtual server
 
@@ -1402,7 +1418,11 @@ func handleRefreshToken(w http.ResponseWriter, r *http.Request) {
 	}
 
 	keyService := ioc.GetDependency[services.KeyService](scope)
-	keyPair := keyService.GetKey(refreshTokenInfo.VirtualServerName, virtualServer.SigningAlgorithm())
+	keyPair, err := keyService.GetKey(refreshTokenInfo.VirtualServerName, virtualServer.SigningAlgorithm())
+	if err != nil {
+		utils.HandleHttpError(w, err)
+		return
+	}
 
 	tokenDuration := time.Hour // TODO: make this configurable per virtual server
 
@@ -1652,7 +1672,11 @@ func handleTokenExchange(w http.ResponseWriter, r *http.Request) {
 	}
 
 	keyService := ioc.GetDependency[services.KeyService](scope)
-	keyPair := keyService.GetKey(virtualServerName, virtualServer.SigningAlgorithm())
+	keyPair, err := keyService.GetKey(virtualServerName, virtualServer.SigningAlgorithm())
+	if err != nil {
+		utils.HandleHttpError(w, err)
+		return
+	}
 
 	clockService := ioc.GetDependency[clock.Service](scope)
 	now := clockService.Now()
@@ -1918,7 +1942,11 @@ func handleDeviceCodeGrant(w http.ResponseWriter, r *http.Request) {
 	}
 
 	keyService := ioc.GetDependency[services.KeyService](scope)
-	keyPair := keyService.GetKey(deviceCodeInfo.VirtualServerName, virtualServer.SigningAlgorithm())
+	keyPair, err := keyService.GetKey(deviceCodeInfo.VirtualServerName, virtualServer.SigningAlgorithm())
+	if err != nil {
+		utils.HandleHttpError(w, err)
+		return
+	}
 
 	clockService := ioc.GetDependency[clock.Service](scope)
 	now := clockService.Now()

--- a/internal/services/keys.go
+++ b/internal/services/keys.go
@@ -22,6 +22,8 @@ import (
 	"github.com/The127/go-clock"
 
 	vault "github.com/hashicorp/vault/api"
+
+	"github.com/The127/Keyline/utils"
 )
 
 type KeyAlgorithmStrategy interface {
@@ -699,7 +701,7 @@ func (k *KeyPair) ExpiresAt() time.Time {
 //go:generate mockgen -destination=./mocks/key_service.go -package=mocks Keyline/internal/services KeyService
 type KeyService interface {
 	Generate(clockService clock.Service, virtualServerName string, algorithm config.SigningAlgorithm) (KeyPair, error)
-	GetKey(virtualServerName string, algorithm config.SigningAlgorithm) KeyPair
+	GetKey(virtualServerName string, algorithm config.SigningAlgorithm) (KeyPair, error)
 }
 
 type keyServiceImpl struct {
@@ -729,16 +731,16 @@ func (s *keyServiceImpl) Generate(clockService clock.Service, virtualServerName 
 	return keyPair, nil
 }
 
-func (s *keyServiceImpl) GetKey(virtualServerName string, algorithm config.SigningAlgorithm) KeyPair {
+func (s *keyServiceImpl) GetKey(virtualServerName string, algorithm config.SigningAlgorithm) (KeyPair, error) {
 	keyPair, ok := s.cache.TryGet(virtualServerName)
 	if !ok {
 		keyPairs, err := s.store.GetAllForAlgorithm(virtualServerName, algorithm)
 		if err != nil {
-			panic(fmt.Errorf("getting key pairs: %w", err))
+			return KeyPair{}, fmt.Errorf("getting key pairs: %w", err)
 		}
 
 		if len(keyPairs) == 0 {
-			panic(fmt.Errorf("no key pairs found for virtual server %s", virtualServerName))
+			return KeyPair{}, fmt.Errorf("no signing keys for virtual server %s: %w", virtualServerName, utils.ErrHttpServiceUnavailable)
 		}
 
 		keyPair = keyPairs[0]
@@ -746,8 +748,8 @@ func (s *keyServiceImpl) GetKey(virtualServerName string, algorithm config.Signi
 	}
 
 	if keyPair.Algorithm() != algorithm {
-		panic(fmt.Errorf("key pair algorithm does not match requested algorithm: %s != %s (multiple keys are not implemented yet)", keyPair.Algorithm(), algorithm))
+		return KeyPair{}, fmt.Errorf("key pair algorithm mismatch: %s != %s", keyPair.Algorithm(), algorithm)
 	}
 
-	return keyPair
+	return keyPair, nil
 }

--- a/internal/services/mocks/key_service.go
+++ b/internal/services/mocks/key_service.go
@@ -58,11 +58,12 @@ func (mr *MockKeyServiceMockRecorder) Generate(clockService, virtualServerName, 
 }
 
 // GetKey mocks base method.
-func (m *MockKeyService) GetKey(virtualServerName string, algorithm config.SigningAlgorithm) services.KeyPair {
+func (m *MockKeyService) GetKey(virtualServerName string, algorithm config.SigningAlgorithm) (services.KeyPair, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetKey", virtualServerName, algorithm)
 	ret0, _ := ret[0].(services.KeyPair)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetKey indicates an expected call of GetKey.

--- a/utils/errors.go
+++ b/utils/errors.go
@@ -32,6 +32,8 @@ var ErrInvalidUuid = fmt.Errorf("invalid uuid: %w", ErrHttpBadRequest)
 
 var ErrHttpConflict = errors.New("conflict")
 
+var ErrHttpServiceUnavailable = errors.New("service unavailable")
+
 func HandleHttpError(w http.ResponseWriter, err error) {
 	var status int
 	var msg string
@@ -51,6 +53,10 @@ func HandleHttpError(w http.ResponseWriter, err error) {
 
 	case errors.Is(err, ErrHttpConflict):
 		status = http.StatusConflict
+		msg = err.Error()
+
+	case errors.Is(err, ErrHttpServiceUnavailable):
+		status = http.StatusServiceUnavailable
 		msg = err.Error()
 
 	default:


### PR DESCRIPTION
## Summary

- `system:system-admin` tokens are issued and signed by the initial VS, but were being validated against the requested VS's signing key — causing 401s on any non-initial VS endpoint
- When validation against the requested VS key fails, the middleware now retries with the initial VS's signing key
- Only `system:` prefixed roles are processed regardless, so no VS-specific permissions can leak across tenant boundaries

## Test plan

- [ ] Obtain a `system:system-admin` token from the initial VS
- [ ] Use that token against an endpoint scoped to a different VS (e.g. `GET /api/virtual-servers/{other-vs}/...`) — should now return 200 instead of 401
- [ ] Confirm tokens from non-initial VSes still cannot be used against other VSes
- [ ] Confirm expired/invalid tokens are still rejected