### PR TITLE
fix: use *bool for EmailVerified in CreateUserRequestDto

### DIFF
--- a/api/users.go
+++ b/api/users.go
@@ -17,7 +17,7 @@ type CreateUserRequestDto struct {
 	Username      string                       `json:"username" validate:"required"`
 	DisplayName   string                       `json:"displayName" validate:"required"`
 	Email         string                       `json:"email" validate:"required"`
-	EmailVerified bool                         `json:"emailVerified" validate:"required"`
+	EmailVerified *bool                        `json:"emailVerified"`
 	Password      *CreateUserRequestDtoPasword `json:"password"`
 }
 

--- a/internal/handlers/users.go
+++ b/internal/handlers/users.go
@@ -155,7 +155,7 @@ func CreateUser(w http.ResponseWriter, r *http.Request) {
 		Username:          dto.Username,
 		DisplayName:       dto.DisplayName,
 		Email:             dto.Email,
-		EmailVerified:     dto.EmailVerified,
+		EmailVerified:     utils.ZeroIfNil(dto.EmailVerified),
 	})
 	if err != nil {
 		utils.HandleHttpError(w, err)


### PR DESCRIPTION
## Summary
- `EmailVerified bool` with `validate:"required"` caused user creation to always fail when `emailVerified: false` was sent, because go-playground/validator rejects the zero value of a bool
- Changed to `*bool` with no required tag; handler uses `utils.ZeroIfNil` to default to `false` when omitted

## Test plan
- [ ] Create a user via the UI without checking email verified — should succeed
- [ ] Create a user with `emailVerified: true` — should still work
- [ ] Create a user without sending `emailVerified` at all — should default to `false`