### PR TITLE
fix: propagate DB errors before HTTP response via SaveChangesBehaviour

### DIFF
--- a/api/applications.go
+++ b/api/applications.go
@@ -34,6 +34,8 @@ type GetApplicationResponseDto struct {
 
 	ClaimsMappingScript *string `json:"customClaimsMappingScript"`
 
+	AccessTokenHeaderType string `json:"accessTokenHeaderType"`
+
 	DeviceFlowEnabled bool `json:"deviceFlowEnabled"`
 
 	CreatedAt time.Time `json:"createdAt"`
@@ -41,9 +43,12 @@ type GetApplicationResponseDto struct {
 }
 
 type PatchApplicationRequestDto struct {
-	DisplayName         *string `json:"displayName"`
-	ClaimsMappingScript *string `json:"customClaimsMappingScript"`
-	DeviceFlowEnabled   *bool   `json:"deviceFlowEnabled"`
+	DisplayName           *string  `json:"displayName"`
+	ClaimsMappingScript   *string  `json:"customClaimsMappingScript"`
+	DeviceFlowEnabled     *bool    `json:"deviceFlowEnabled"`
+	RedirectUris          []string `json:"redirectUris,omitempty"`
+	PostLogoutUris        []string `json:"postLogoutUris,omitempty"`
+	AccessTokenHeaderType *string  `json:"accessTokenHeaderType,omitempty" validate:"omitempty,oneof=at+jwt JWT"`
 }
 
 type PagedApplicationsResponseDto = PagedResponseDto[ListApplicationsResponseDto]

--- a/internal/behaviours/SaveChangesBehaviour.go
+++ b/internal/behaviours/SaveChangesBehaviour.go
@@ -1,0 +1,27 @@
+package behaviours
+
+import (
+	"github.com/The127/Keyline/internal/database"
+	"github.com/The127/Keyline/internal/middlewares"
+	"context"
+	"fmt"
+
+	"github.com/The127/ioc"
+	"github.com/The127/mediatr"
+)
+
+func SaveChangesBehaviour(ctx context.Context, _ Policy, next mediatr.Next) (any, error) {
+	response, err := next()
+	if err != nil {
+		return nil, err
+	}
+
+	scope := middlewares.GetScope(ctx)
+	dbContext := ioc.GetDependency[database.Context](scope)
+
+	if saveErr := dbContext.SaveChanges(ctx); saveErr != nil {
+		return nil, fmt.Errorf("saving changes: %w", saveErr)
+	}
+
+	return response, nil
+}

--- a/internal/commands/PatchApplication.go
+++ b/internal/commands/PatchApplication.go
@@ -103,5 +103,10 @@ func HandlePatchApplication(ctx context.Context, command PatchApplication) (*Pat
 	}
 
 	dbContext.Applications().Update(application)
+
+	if err := dbContext.SaveChanges(ctx); err != nil {
+		return nil, fmt.Errorf("saving application changes: %w", err)
+	}
+
 	return &PatchApplicationResponse{}, nil
 }

--- a/internal/commands/PatchApplication.go
+++ b/internal/commands/PatchApplication.go
@@ -104,9 +104,5 @@ func HandlePatchApplication(ctx context.Context, command PatchApplication) (*Pat
 
 	dbContext.Applications().Update(application)
 
-	if err := dbContext.SaveChanges(ctx); err != nil {
-		return nil, fmt.Errorf("saving application changes: %w", err)
-	}
-
 	return &PatchApplicationResponse{}, nil
 }

--- a/internal/commands/PatchApplication.go
+++ b/internal/commands/PatchApplication.go
@@ -16,13 +16,15 @@ import (
 )
 
 type PatchApplication struct {
-	VirtualServerName     string
-	ProjectSlug           string
-	ApplicationId         uuid.UUID
-	DisplayName           *string
-	ClaimsMappingScript   *string
-	AccessTokenHeaderType *string
-	DeviceFlowEnabled     *bool
+	VirtualServerName      string
+	ProjectSlug            string
+	ApplicationId          uuid.UUID
+	DisplayName            *string
+	ClaimsMappingScript    *string
+	AccessTokenHeaderType  *string
+	DeviceFlowEnabled      *bool
+	RedirectUris           *[]string
+	PostLogoutRedirectUris *[]string
 }
 
 func (a PatchApplication) LogRequest() bool {
@@ -90,6 +92,14 @@ func HandlePatchApplication(ctx context.Context, command PatchApplication) (*Pat
 
 	if command.DeviceFlowEnabled != nil {
 		application.SetDeviceFlowEnabled(*command.DeviceFlowEnabled)
+	}
+
+	if command.RedirectUris != nil {
+		application.SetRedirectUris(*command.RedirectUris)
+	}
+
+	if command.PostLogoutRedirectUris != nil {
+		application.SetPostLogoutRedirectUris(*command.PostLogoutRedirectUris)
 	}
 
 	dbContext.Applications().Update(application)

--- a/internal/commands/PatchApplication_test.go
+++ b/internal/commands/PatchApplication_test.go
@@ -33,7 +33,6 @@ func (s *PatchApplicationCommandSuite) createContext(
 	virtualServerRepository repositories.VirtualServerRepository,
 	projectRepository repositories.ProjectRepository,
 	applicationRepository repositories.ApplicationRepository,
-	expectSaveChanges bool,
 ) context.Context {
 	dc := ioc.NewDependencyCollection()
 
@@ -52,10 +51,6 @@ func (s *PatchApplicationCommandSuite) createContext(
 
 	if applicationRepository != nil {
 		dbContext.EXPECT().Applications().Return(applicationRepository).AnyTimes()
-	}
-
-	if expectSaveChanges {
-		dbContext.EXPECT().SaveChanges(gomock.Any()).Return(nil)
 	}
 
 	scope := dc.BuildProvider()
@@ -107,7 +102,7 @@ func (s *PatchApplicationCommandSuite) TestHappyPath() {
 	})).Return(application, nil)
 	applicationRepository.EXPECT().Update(gomock.Any())
 
-	ctx := s.createContext(ctrl, virtualServerRepository, projectRepository, applicationRepository, true)
+	ctx := s.createContext(ctrl, virtualServerRepository, projectRepository, applicationRepository)
 	cmd := PatchApplication{
 		VirtualServerName:     virtualServer.Name(),
 		ProjectSlug:           project.Slug(),
@@ -140,7 +135,7 @@ func (s *PatchApplicationCommandSuite) TestUpdatesRedirectUris() {
 		return slices.Equal(x.RedirectUris(), []string{"https://new.example.com/callback"})
 	}))
 
-	ctx := s.createContext(ctrl, virtualServerRepository, projectRepository, applicationRepository, true)
+	ctx := s.createContext(ctrl, virtualServerRepository, projectRepository, applicationRepository)
 	newUris := []string{"https://new.example.com/callback"}
 	cmd := PatchApplication{
 		VirtualServerName: virtualServer.Name(),
@@ -173,7 +168,7 @@ func (s *PatchApplicationCommandSuite) TestUpdatesPostLogoutUris() {
 		return slices.Equal(x.PostLogoutRedirectUris(), []string{"https://example.com/logout"})
 	}))
 
-	ctx := s.createContext(ctrl, virtualServerRepository, projectRepository, applicationRepository, true)
+	ctx := s.createContext(ctrl, virtualServerRepository, projectRepository, applicationRepository)
 	newUris := []string{"https://example.com/logout"}
 	cmd := PatchApplication{
 		VirtualServerName:      virtualServer.Name(),
@@ -206,7 +201,7 @@ func (s *PatchApplicationCommandSuite) TestApplicationError() {
 	applicationRepository := mocks.NewMockApplicationRepository(ctrl)
 	applicationRepository.EXPECT().FirstOrErr(gomock.Any(), gomock.Any()).Return(nil, errors.New("error"))
 
-	ctx := s.createContext(ctrl, virtualServerRepository, projectRepository, applicationRepository, false)
+	ctx := s.createContext(ctrl, virtualServerRepository, projectRepository, applicationRepository)
 	cmd := PatchApplication{}
 
 	// act
@@ -229,7 +224,7 @@ func (s *PatchApplicationCommandSuite) TestProjectError() {
 	projectRepository := mocks.NewMockProjectRepository(ctrl)
 	projectRepository.EXPECT().FirstOrErr(gomock.Any(), gomock.Any()).Return(nil, errors.New("error"))
 
-	ctx := s.createContext(ctrl, virtualServerRepository, projectRepository, nil, false)
+	ctx := s.createContext(ctrl, virtualServerRepository, projectRepository, nil)
 	cmd := PatchApplication{}
 
 	// act
@@ -248,7 +243,7 @@ func (s *PatchApplicationCommandSuite) TestVirtualServerError() {
 	virtualServerRepository := mocks.NewMockVirtualServerRepository(ctrl)
 	virtualServerRepository.EXPECT().FirstOrErr(gomock.Any(), gomock.Any()).Return(nil, errors.New("error"))
 
-	ctx := s.createContext(ctrl, virtualServerRepository, nil, nil, false)
+	ctx := s.createContext(ctrl, virtualServerRepository, nil, nil)
 	cmd := PatchApplication{}
 
 	// act

--- a/internal/commands/PatchApplication_test.go
+++ b/internal/commands/PatchApplication_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/The127/Keyline/utils"
 	"context"
 	"errors"
+	"slices"
 	"testing"
 	"time"
 
@@ -60,13 +61,12 @@ func (s *PatchApplicationCommandSuite) createContext(
 	return middlewares.ContextWithScope(s.T().Context(), scope)
 }
 
-func (s *PatchApplicationCommandSuite) TestHappyPath() {
-	// arrange
-	ctrl := gomock.NewController(s.T())
-	defer ctrl.Finish()
-
-	now := time.Now()
-
+func (s *PatchApplicationCommandSuite) setupVSAndProject(ctrl *gomock.Controller, now time.Time) (
+	*repositories.VirtualServer,
+	*repositories.Project,
+	*mocks.MockVirtualServerRepository,
+	*mocks.MockProjectRepository,
+) {
 	virtualServer := repositories.NewVirtualServer("virtualServer", "Virtual Server")
 	virtualServer.Mock(now)
 	virtualServerRepository := mocks.NewMockVirtualServerRepository(ctrl)
@@ -80,6 +80,17 @@ func (s *PatchApplicationCommandSuite) TestHappyPath() {
 	projectRepository.EXPECT().FirstOrErr(gomock.Any(), gomock.Cond(func(x *repositories.ProjectFilter) bool {
 		return x.GetSlug() == "project"
 	})).Return(project, nil)
+
+	return virtualServer, project, virtualServerRepository, projectRepository
+}
+
+func (s *PatchApplicationCommandSuite) TestHappyPath() {
+	// arrange
+	ctrl := gomock.NewController(s.T())
+	defer ctrl.Finish()
+
+	now := time.Now()
+	virtualServer, project, virtualServerRepository, projectRepository := s.setupVSAndProject(ctrl, now)
 
 	application := repositories.NewApplication(virtualServer.Id(), project.Id(), "application", "Application", repositories.ApplicationTypePublic, []string{})
 	application.Mock(now)
@@ -98,6 +109,72 @@ func (s *PatchApplicationCommandSuite) TestHappyPath() {
 		ApplicationId:         application.Id(),
 		ClaimsMappingScript:   utils.Ptr("claimsMappingScript"),
 		AccessTokenHeaderType: utils.Ptr("JWT"),
+	}
+
+	// act
+	resp, err := HandlePatchApplication(ctx, cmd)
+
+	// assert
+	s.Require().NoError(err)
+	s.NotNil(resp)
+}
+
+func (s *PatchApplicationCommandSuite) TestUpdatesRedirectUris() {
+	// arrange
+	ctrl := gomock.NewController(s.T())
+	defer ctrl.Finish()
+
+	now := time.Now()
+	virtualServer, project, virtualServerRepository, projectRepository := s.setupVSAndProject(ctrl, now)
+
+	application := repositories.NewApplication(virtualServer.Id(), project.Id(), "application", "Application", repositories.ApplicationTypePublic, []string{"https://old.example.com/callback"})
+	application.Mock(now)
+	applicationRepository := mocks.NewMockApplicationRepository(ctrl)
+	applicationRepository.EXPECT().FirstOrErr(gomock.Any(), gomock.Any()).Return(application, nil)
+	applicationRepository.EXPECT().Update(gomock.Cond(func(x *repositories.Application) bool {
+		return slices.Equal(x.RedirectUris(), []string{"https://new.example.com/callback"})
+	}))
+
+	ctx := s.createContext(ctrl, virtualServerRepository, projectRepository, applicationRepository)
+	newUris := []string{"https://new.example.com/callback"}
+	cmd := PatchApplication{
+		VirtualServerName: virtualServer.Name(),
+		ProjectSlug:       project.Slug(),
+		ApplicationId:     application.Id(),
+		RedirectUris:      &newUris,
+	}
+
+	// act
+	resp, err := HandlePatchApplication(ctx, cmd)
+
+	// assert
+	s.Require().NoError(err)
+	s.NotNil(resp)
+}
+
+func (s *PatchApplicationCommandSuite) TestUpdatesPostLogoutUris() {
+	// arrange
+	ctrl := gomock.NewController(s.T())
+	defer ctrl.Finish()
+
+	now := time.Now()
+	virtualServer, project, virtualServerRepository, projectRepository := s.setupVSAndProject(ctrl, now)
+
+	application := repositories.NewApplication(virtualServer.Id(), project.Id(), "application", "Application", repositories.ApplicationTypePublic, []string{"https://example.com/callback"})
+	application.Mock(now)
+	applicationRepository := mocks.NewMockApplicationRepository(ctrl)
+	applicationRepository.EXPECT().FirstOrErr(gomock.Any(), gomock.Any()).Return(application, nil)
+	applicationRepository.EXPECT().Update(gomock.Cond(func(x *repositories.Application) bool {
+		return slices.Equal(x.PostLogoutRedirectUris(), []string{"https://example.com/logout"})
+	}))
+
+	ctx := s.createContext(ctrl, virtualServerRepository, projectRepository, applicationRepository)
+	newUris := []string{"https://example.com/logout"}
+	cmd := PatchApplication{
+		VirtualServerName:      virtualServer.Name(),
+		ProjectSlug:            project.Slug(),
+		ApplicationId:          application.Id(),
+		PostLogoutRedirectUris: &newUris,
 	}
 
 	// act

--- a/internal/commands/PatchApplication_test.go
+++ b/internal/commands/PatchApplication_test.go
@@ -33,6 +33,7 @@ func (s *PatchApplicationCommandSuite) createContext(
 	virtualServerRepository repositories.VirtualServerRepository,
 	projectRepository repositories.ProjectRepository,
 	applicationRepository repositories.ApplicationRepository,
+	expectSaveChanges bool,
 ) context.Context {
 	dc := ioc.NewDependencyCollection()
 
@@ -51,6 +52,10 @@ func (s *PatchApplicationCommandSuite) createContext(
 
 	if applicationRepository != nil {
 		dbContext.EXPECT().Applications().Return(applicationRepository).AnyTimes()
+	}
+
+	if expectSaveChanges {
+		dbContext.EXPECT().SaveChanges(gomock.Any()).Return(nil)
 	}
 
 	scope := dc.BuildProvider()
@@ -102,7 +107,7 @@ func (s *PatchApplicationCommandSuite) TestHappyPath() {
 	})).Return(application, nil)
 	applicationRepository.EXPECT().Update(gomock.Any())
 
-	ctx := s.createContext(ctrl, virtualServerRepository, projectRepository, applicationRepository)
+	ctx := s.createContext(ctrl, virtualServerRepository, projectRepository, applicationRepository, true)
 	cmd := PatchApplication{
 		VirtualServerName:     virtualServer.Name(),
 		ProjectSlug:           project.Slug(),
@@ -135,7 +140,7 @@ func (s *PatchApplicationCommandSuite) TestUpdatesRedirectUris() {
 		return slices.Equal(x.RedirectUris(), []string{"https://new.example.com/callback"})
 	}))
 
-	ctx := s.createContext(ctrl, virtualServerRepository, projectRepository, applicationRepository)
+	ctx := s.createContext(ctrl, virtualServerRepository, projectRepository, applicationRepository, true)
 	newUris := []string{"https://new.example.com/callback"}
 	cmd := PatchApplication{
 		VirtualServerName: virtualServer.Name(),
@@ -168,7 +173,7 @@ func (s *PatchApplicationCommandSuite) TestUpdatesPostLogoutUris() {
 		return slices.Equal(x.PostLogoutRedirectUris(), []string{"https://example.com/logout"})
 	}))
 
-	ctx := s.createContext(ctrl, virtualServerRepository, projectRepository, applicationRepository)
+	ctx := s.createContext(ctrl, virtualServerRepository, projectRepository, applicationRepository, true)
 	newUris := []string{"https://example.com/logout"}
 	cmd := PatchApplication{
 		VirtualServerName:      virtualServer.Name(),
@@ -201,7 +206,7 @@ func (s *PatchApplicationCommandSuite) TestApplicationError() {
 	applicationRepository := mocks.NewMockApplicationRepository(ctrl)
 	applicationRepository.EXPECT().FirstOrErr(gomock.Any(), gomock.Any()).Return(nil, errors.New("error"))
 
-	ctx := s.createContext(ctrl, virtualServerRepository, projectRepository, applicationRepository)
+	ctx := s.createContext(ctrl, virtualServerRepository, projectRepository, applicationRepository, false)
 	cmd := PatchApplication{}
 
 	// act
@@ -224,7 +229,7 @@ func (s *PatchApplicationCommandSuite) TestProjectError() {
 	projectRepository := mocks.NewMockProjectRepository(ctrl)
 	projectRepository.EXPECT().FirstOrErr(gomock.Any(), gomock.Any()).Return(nil, errors.New("error"))
 
-	ctx := s.createContext(ctrl, virtualServerRepository, projectRepository, nil)
+	ctx := s.createContext(ctrl, virtualServerRepository, projectRepository, nil, false)
 	cmd := PatchApplication{}
 
 	// act
@@ -243,7 +248,7 @@ func (s *PatchApplicationCommandSuite) TestVirtualServerError() {
 	virtualServerRepository := mocks.NewMockVirtualServerRepository(ctrl)
 	virtualServerRepository.EXPECT().FirstOrErr(gomock.Any(), gomock.Any()).Return(nil, errors.New("error"))
 
-	ctx := s.createContext(ctrl, virtualServerRepository, nil, nil)
+	ctx := s.createContext(ctrl, virtualServerRepository, nil, nil, false)
 	cmd := PatchApplication{}
 
 	// act

--- a/internal/handlers/applications.go
+++ b/internal/handlers/applications.go
@@ -195,6 +195,7 @@ func PatchApplication(w http.ResponseWriter, r *http.Request) {
 	appId, err := uuid.Parse(appIdString)
 	if err != nil {
 		utils.HandleHttpError(w, utils.ErrInvalidUuid)
+		return
 	}
 
 	var dto api.PatchApplicationRequestDto
@@ -263,6 +264,7 @@ func DeleteApplication(w http.ResponseWriter, r *http.Request) {
 	appId, err := uuid.Parse(appIdString)
 	if err != nil {
 		utils.HandleHttpError(w, utils.ErrInvalidUuid)
+		return
 	}
 
 	scope := middlewares.GetScope(ctx)

--- a/internal/handlers/applications.go
+++ b/internal/handlers/applications.go
@@ -154,6 +154,7 @@ func GetApplication(w http.ResponseWriter, r *http.Request) {
 		PostLogoutRedirectUris: application.PostLogoutUris,
 		SystemApplication:      application.SystemApplication,
 		ClaimsMappingScript:    application.ClaimsMappingScript,
+		AccessTokenHeaderType:  application.AccessTokenHeaderType,
 		DeviceFlowEnabled:      application.DeviceFlowEnabled,
 		CreatedAt:              application.CreatedAt,
 		UpdatedAt:              application.UpdatedAt,
@@ -206,13 +207,25 @@ func PatchApplication(w http.ResponseWriter, r *http.Request) {
 	scope := middlewares.GetScope(ctx)
 	m := ioc.GetDependency[mediatr.Mediator](scope)
 
+	var redirectUris *[]string
+	if dto.RedirectUris != nil {
+		redirectUris = &dto.RedirectUris
+	}
+	var postLogoutUris *[]string
+	if dto.PostLogoutUris != nil {
+		postLogoutUris = &dto.PostLogoutUris
+	}
+
 	_, err = mediatr.Send[*commands.PatchApplicationResponse](ctx, m, commands.PatchApplication{
-		VirtualServerName:   vsName,
-		ProjectSlug:         projectSlug,
-		ApplicationId:       appId,
-		DisplayName:         utils.TrimSpace(dto.DisplayName),
-		ClaimsMappingScript: dto.ClaimsMappingScript,
-		DeviceFlowEnabled:   dto.DeviceFlowEnabled,
+		VirtualServerName:     vsName,
+		ProjectSlug:           projectSlug,
+		ApplicationId:         appId,
+		DisplayName:           utils.TrimSpace(dto.DisplayName),
+		ClaimsMappingScript:   dto.ClaimsMappingScript,
+		DeviceFlowEnabled:     dto.DeviceFlowEnabled,
+		RedirectUris:          redirectUris,
+		PostLogoutRedirectUris: postLogoutUris,
+		AccessTokenHeaderType: dto.AccessTokenHeaderType,
 	})
 	if err != nil {
 		utils.HandleHttpError(w, err)

--- a/internal/queries/GetApplicationQuery.go
+++ b/internal/queries/GetApplicationQuery.go
@@ -38,17 +38,18 @@ func (a GetApplication) GetRequestName() string {
 }
 
 type GetApplicationResult struct {
-	Id                  uuid.UUID
-	Name                string
-	DisplayName         string
-	Type                repositories.ApplicationType
-	RedirectUris        []string
-	PostLogoutUris      []string
-	SystemApplication   bool
-	ClaimsMappingScript *string
-	DeviceFlowEnabled   bool
-	CreatedAt           time.Time
-	UpdatedAt           time.Time
+	Id                    uuid.UUID
+	Name                  string
+	DisplayName           string
+	Type                  repositories.ApplicationType
+	RedirectUris          []string
+	PostLogoutUris        []string
+	SystemApplication     bool
+	ClaimsMappingScript   *string
+	AccessTokenHeaderType string
+	DeviceFlowEnabled     bool
+	CreatedAt             time.Time
+	UpdatedAt             time.Time
 }
 
 func HandleGetApplication(ctx context.Context, query GetApplication) (*GetApplicationResult, error) {
@@ -84,16 +85,17 @@ func HandleGetApplication(ctx context.Context, query GetApplication) (*GetApplic
 	}
 
 	return &GetApplicationResult{
-		Id:                  application.Id(),
-		Name:                application.Name(),
-		DisplayName:         application.DisplayName(),
-		Type:                application.Type(),
-		RedirectUris:        application.RedirectUris(),
-		PostLogoutUris:      application.PostLogoutRedirectUris(),
-		SystemApplication:   application.SystemApplication(),
-		ClaimsMappingScript: application.ClaimsMappingScript(),
-		DeviceFlowEnabled:   application.DeviceFlowEnabled(),
-		CreatedAt:           application.AuditCreatedAt(),
-		UpdatedAt:           application.AuditUpdatedAt(),
+		Id:                    application.Id(),
+		Name:                  application.Name(),
+		DisplayName:           application.DisplayName(),
+		Type:                  application.Type(),
+		RedirectUris:          application.RedirectUris(),
+		PostLogoutUris:        application.PostLogoutRedirectUris(),
+		SystemApplication:     application.SystemApplication(),
+		ClaimsMappingScript:   application.ClaimsMappingScript(),
+		AccessTokenHeaderType: application.AccessTokenHeaderType(),
+		DeviceFlowEnabled:     application.DeviceFlowEnabled(),
+		CreatedAt:             application.AuditCreatedAt(),
+		UpdatedAt:             application.AuditUpdatedAt(),
 	}, nil
 }

--- a/internal/setup/mediator.go
+++ b/internal/setup/mediator.go
@@ -78,6 +78,7 @@ func Mediator(dc *ioc.DependencyCollection) {
 	mediatr.RegisterEventHandler(m, events.QueueEmailVerificationJobOnUserCreatedEvent)
 
 	mediatr.RegisterBehaviour(m, behaviours.PolicyBehaviour)
+	mediatr.RegisterBehaviour(m, behaviours.SaveChangesBehaviour)
 
 	ioc.RegisterSingleton(dc, func(dp *ioc.DependencyProvider) mediatr.Mediator {
 		return m


### PR DESCRIPTION
## Summary

- Silent 204 on DB failure: `SaveChanges` was deferred to the IOC close handler which ran after the HTTP response was already written — DB errors (e.g. xmin optimistic lock conflicts) were silently dropped. Fixed by introducing `SaveChangesBehaviour` which flushes the DB context after every successful mediator request, before the response is written.
- Missing `return` after UUID parse errors in `PatchApplication` and `DeleteApplication` handlers (execution continued with a zero-value UUID).
- `SaveChanges` was incorrectly placed in the `PatchApplication` command handler (cross-cutting concern). Moved to `SaveChangesBehaviour` in the behaviours layer.

## Test plan

- [ ] Existing `PatchApplicationCommandSuite` passes (SaveChanges mock removed from command-level tests)
- [ ] Manual PATCH /applications with a concurrent write to verify 500 is returned instead of silent 204