### PR TITLE
feat: add UserClient.Create to API client

### DIFF
--- a/client/user.go
+++ b/client/user.go
@@ -18,6 +18,7 @@ type ListUserParams struct {
 }
 
 type UserClient interface {
+	Create(ctx context.Context, dto api.CreateUserRequestDto) (api.CreateUserResponseDto, error)
 	List(ctx context.Context, params ListUserParams) (api.PagedUsersResponseDto, error)
 	Get(ctx context.Context, id uuid.UUID) (api.GetUserByIdResponseDto, error)
 	Patch(ctx context.Context, id uuid.UUID, dto api.PatchUserRequestDto) error
@@ -33,6 +34,32 @@ func NewUserClient(transport *Transport) UserClient {
 
 type userClient struct {
 	transport *Transport
+}
+
+func (c *userClient) Create(ctx context.Context, dto api.CreateUserRequestDto) (api.CreateUserResponseDto, error) {
+	jsonBytes, err := json.Marshal(dto)
+	if err != nil {
+		return api.CreateUserResponseDto{}, fmt.Errorf("marshaling dto: %w", err)
+	}
+
+	request, err := c.transport.NewTenantRequest(ctx, http.MethodPost, "/users", bytes.NewBuffer(jsonBytes))
+	if err != nil {
+		return api.CreateUserResponseDto{}, fmt.Errorf("creating request: %w", err)
+	}
+
+	response, err := c.transport.Do(request)
+	if err != nil {
+		return api.CreateUserResponseDto{}, fmt.Errorf("doing request: %w", err)
+	}
+	defer response.Body.Close() //nolint:errcheck
+
+	var responseDto api.CreateUserResponseDto
+	err = json.NewDecoder(response.Body).Decode(&responseDto)
+	if err != nil {
+		return api.CreateUserResponseDto{}, fmt.Errorf("decoding response: %w", err)
+	}
+
+	return responseDto, nil
 }
 
 func (c *userClient) List(ctx context.Context, params ListUserParams) (api.PagedUsersResponseDto, error) {

--- a/client/user_test.go
+++ b/client/user_test.go
@@ -22,6 +22,47 @@ func TestUserClientSuite(t *testing.T) {
 	suite.Run(t, new(UserClientSuite))
 }
 
+func (s *UserClientSuite) TestCreateUser_HappyPath() {
+	// arrange
+	request := api.CreateUserRequestDto{
+		Username:      "newuser",
+		DisplayName:   "New User",
+		Email:         "newuser@example.com",
+		EmailVerified: utils.Ptr(true),
+		Password: &api.CreateUserRequestDtoPasword{
+			Plain:     "hunter2",
+			Temporary: true,
+		},
+	}
+	response := api.CreateUserResponseDto{
+		Id: uuid.New(),
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.Equal(http.MethodPost, r.Method)
+		s.Equal("/api/virtual-servers/test/users", r.URL.Path)
+
+		var requestDto api.CreateUserRequestDto
+		err := json.NewDecoder(r.Body).Decode(&requestDto)
+		s.NoError(err)
+		s.Equal(request, requestDto)
+
+		w.WriteHeader(http.StatusCreated)
+		err = json.NewEncoder(w).Encode(response)
+		s.NoError(err)
+	}))
+	defer server.Close()
+
+	testee := NewClient(server.URL, "test").User()
+
+	// act
+	responseDto, err := testee.Create(s.T().Context(), request)
+
+	// assert
+	s.Require().NoError(err)
+	s.Equal(response, responseDto)
+}
+
 func (s *UserClientSuite) TestListUsers_HappyPath() {
 	// arrange
 	requestParams := ListUserParams{

--- a/tests/e2e/userclient_test.go
+++ b/tests/e2e/userclient_test.go
@@ -1,0 +1,88 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+
+	"github.com/The127/Keyline/api"
+	"github.com/The127/Keyline/client"
+	"github.com/The127/Keyline/config"
+	"github.com/The127/Keyline/internal/commands"
+	"github.com/The127/Keyline/utils"
+
+	"golang.org/x/oauth2"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// serviceUserTokenSource returns a token source signed with the harness's default
+// service user private key, targeting the given VS's admin application.
+func serviceUserTokenSource(ctx context.Context, url string) oauth2.TokenSource {
+	return &client.ServiceUserTokenSource{
+		KeylineURL:    url,
+		VirtualServer: "test-vs",
+		PrivKeyPEM:    serviceUserPrivateKey,
+		Kid:           serviceUserKid,
+		Username:      serviceUserUsername,
+		Application:   commands.AdminApplicationName,
+	}
+}
+
+func init() {
+	for _, backend := range testBackends {
+		backend := backend
+		Describe("User client Create ["+backend.name+"]", Ordered, func() {
+			var h *harness
+
+			BeforeAll(func() {
+				if backend.dbMode == config.DatabaseModePostgres && !postgresBackendAvailable() {
+					Skip("Postgres not available")
+				}
+				h = newE2eTestHarness(backend.dbMode, serviceUserTokenSource)
+			})
+
+			AfterAll(func() {
+				if h != nil {
+					h.Close()
+				}
+			})
+
+			It("creates a user and returns its id", func() {
+				resp, err := h.Client().User().Create(h.Ctx(), api.CreateUserRequestDto{
+					Username:      "e2e-create-user",
+					DisplayName:   "E2E Create User",
+					Email:         "e2e-create-user@localhost",
+					EmailVerified: utils.Ptr(true),
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resp.Id).ToNot(BeZero())
+
+				got, err := h.Client().User().Get(h.Ctx(), resp.Id)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(got.Username).To(Equal("e2e-create-user"))
+				Expect(got.DisplayName).To(Equal("E2E Create User"))
+				Expect(got.PrimaryEmail).To(Equal("e2e-create-user@localhost"))
+				Expect(got.EmailVerified).To(BeTrue())
+				Expect(got.IsServiceUser).To(BeFalse())
+			})
+
+			It("creates a user with a temporary password", func() {
+				resp, err := h.Client().User().Create(h.Ctx(), api.CreateUserRequestDto{
+					Username:    "e2e-temp-password-user",
+					DisplayName: "Temp Password User",
+					Email:       "e2e-temp-password-user@localhost",
+					Password: &api.CreateUserRequestDtoPasword{
+						Plain:     "initial-password",
+						Temporary: true,
+					},
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resp.Id).ToNot(BeZero())
+			})
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `Create(ctx, api.CreateUserRequestDto) (api.CreateUserResponseDto, error)` to the `UserClient` interface. Wraps `POST /api/virtual-servers/{vs}/users` following the existing `Application.Create` pattern.
- Adds a httptest unit test covering method, path, request body, and response decoding.
- Adds an e2e spec (`tests/e2e/userclient_test.go`, `//go:build e2e`) that exercises create + get against the real server with service-user auth, plus a duplicate-username error path.

Motivated by the portal backend's upcoming access-request approval flow, which needs to provision regular users via the Go client.

## Test plan
- [x] \`go test ./client/...\` passes
- [x] \`go vet -tags=e2e ./tests/e2e/...\` clean
- [ ] Full e2e run (needs Postgres + Vault infra)