### PR TITLE
fix(login): use system identity in ResetTemporaryPassword mediator call

### DIFF
--- a/internal/handlers/login.go
+++ b/internal/handlers/login.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/The127/Keyline/config"
+	"github.com/The127/Keyline/internal/authentication"
 	"github.com/The127/Keyline/internal/commands"
 	"github.com/The127/Keyline/internal/database"
 	"github.com/The127/Keyline/internal/jsonTypes"
@@ -621,8 +622,14 @@ func ResetTemporaryPassword(w http.ResponseWriter, r *http.Request) {
 			return err
 		}
 
+		// The login flow is pre-authentication, so /logins/* skips
+		// authentication.Middleware and ctx carries no CurrentUser. Switch
+		// to the system identity for this command: the login token plus the
+		// LoginStepTemporaryPassword guard above are the proof that the
+		// caller is authorised to reset their own temp password.
+		sysCtx := authentication.ContextWithCurrentUser(ctx, authentication.SystemUser())
 		m := ioc.GetDependency[mediatr.Mediator](scope)
-		_, err = mediatr.Send[*commands.SetPasswordResponse](ctx, m, commands.SetPassword{
+		_, err = mediatr.Send[*commands.SetPasswordResponse](sysCtx, m, commands.SetPassword{
 			UserId:      loginInfo.UserId,
 			NewPassword: dto.NewPassword,
 			Temporary:   false,


### PR DESCRIPTION
## Summary
- /logins/* deliberately skips authentication.Middleware (the login flow is pre-authentication; the login token in the URL is the capability, no Bearer token yet). So the request context carries no CurrentUser.
- ResetTemporaryPassword is the only login-flow handler that issues a mediator command (commands.SetPassword). PolicyBehaviour.evaluatePolicy calls authentication.GetCurrentUser unconditionally and panics with "current user not found".
- Inject authentication.SystemUser() into the mediator-call context: PolicyBehaviour short-circuits to Allowed, SetPassword runs. The login token plus the LoginStepTemporaryPassword guard are the proof of authority; the server is acting as a trusted system actor on the user's behalf, which is exactly what authentication.SystemUser() exists for.

## Why this was latent
Until v0.5.2 the access-request approve flow in keyline-saas-admin-api was 401-blocking on POST /api/virtual-servers/portal/users (system-admin role had no user:create permission). Once v0.5.2 fixed that, the first portal user with a temp password reached the reset-temp-password step in production, and the panic surfaced.

## Test plan
- [x] `go build ./...` clean
- [ ] After release: complete an access-request approve, log in with the temp password, reset to a real password — should succeed (currently 500s with handler panic)

## Follow-up worth considering
- No login-handler tests exist today (`internal/handlers/login_test.go` is missing). The login flow is exercised end-to-end nowhere. Worth a focused e2e test pass for the temp-password flow.