### PR TITLE
ci: add trivy scan and cosign attestation to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   packages: write
+  id-token: write
 
 jobs:
   build-and-release:
@@ -29,6 +30,13 @@ jobs:
           file: Containerfile
           push: true
           tags: ghcr.io/the127/keyline:${{ github.ref_name }}
+
+      - uses: sigstore/cosign-installer@v3
+
+      - name: Scan and attest vulnerabilities
+        run: |
+          trivy image --format cosign-vuln --output vuln.json "ghcr.io/the127/keyline:${{ github.ref_name }}"
+          cosign attest --predicate vuln.json --type vuln --yes "ghcr.io/the127/keyline:${{ github.ref_name }}"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3


### PR DESCRIPTION
Adds trivy vulnerability scanning and cosign keyless attestation to the release workflow.

After pushing the image, the workflow:
1. Scans the image with `trivy image --format cosign-vuln`
2. Attests the result with `cosign attest --type vuln` using GitHub Actions OIDC (keyless signing via Sigstore/Fulcio)

The attestation is verified at admission by a Kyverno `verifyImages` policy that blocks pods with CRITICAL vulnerabilities.

Requires `id-token: write` permission for the OIDC token.