### PR TITLE
fix(oidc): bind authorization codes to client, redirect_uri, and PKCE

### DIFF
--- a/internal/handlers/oidc.go
+++ b/internal/handlers/oidc.go
@@ -3,6 +3,8 @@ package handlers
 import (
 	"context"
 	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/subtle"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/binary"
@@ -419,6 +421,32 @@ func BeginAuthorizationFlow(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// PKCE policy (OAuth 2.1): the authorization code flow MUST use PKCE.
+	// We accept S256 only -- "plain" is trivially bypassable by an attacker
+	// who can read the request and is no longer recommended.
+	if authRequest.PKCEChallenge == "" {
+		errorRedirect(w, r, authRequest, OidcError{
+			Error:            "invalid_request",
+			ErrorDescription: "code_challenge is required",
+		})
+		return
+	}
+	if authRequest.PKCEChallengeMethod == "" {
+		// Per RFC 7636 §4.3, omitted method defaults to "plain". We do not allow plain.
+		errorRedirect(w, r, authRequest, OidcError{
+			Error:            "invalid_request",
+			ErrorDescription: "code_challenge_method is required and must be S256",
+		})
+		return
+	}
+	if authRequest.PKCEChallengeMethod != "S256" {
+		errorRedirect(w, r, authRequest, OidcError{
+			Error:            "invalid_request",
+			ErrorDescription: "unsupported code_challenge_method (only S256 is allowed)",
+		})
+		return
+	}
+
 	// TODO: check the scopes for email and profile
 
 	tokenService := ioc.GetDependency[services.TokenService](scope)
@@ -427,7 +455,17 @@ func BeginAuthorizationFlow(w http.ResponseWriter, r *http.Request) {
 	if ok {
 		// TODO: consent page
 
-		codeInfo := jsonTypes.NewCodeInfo(virtualServer.Name(), authRequest.Scopes, s.UserId(), authRequest.Nonce, s.CreatedAt())
+		codeInfo := jsonTypes.NewCodeInfo(
+			virtualServer.Name(),
+			application.Id(),
+			authRequest.Scopes,
+			s.UserId(),
+			authRequest.Nonce,
+			s.CreatedAt(),
+			authRequest.RedirectUri,
+			authRequest.PKCEChallenge,
+			authRequest.PKCEChallengeMethod,
+		)
 
 		codeInfoString, err := json.Marshal(codeInfo)
 		if err != nil {
@@ -860,12 +898,31 @@ func OidcToken(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-//nolint:unparam
-func authenticateApplication(ctx context.Context, applicationName string, applicationSecret string) (*repositories.Application, error) {
+// authenticateApplication looks up an application by name within the given
+// virtual server and verifies client authentication.
+//
+// Authentication rules:
+//   - Confidential clients MUST present a non-empty client_secret that matches
+//     the stored hash. Empty or wrong secret -> error.
+//   - Public clients MUST NOT send a client_secret (they have none registered).
+//     They authenticate the redemption via PKCE, which is checked separately
+//     by the caller against the bound code.
+//
+// The virtual server scoping closes a tenant-isolation bug: previously the
+// lookup was by name only, which would let a confidential client in tenant A
+// authenticate against a token request bound to tenant B (when names collided).
+func authenticateApplication(
+	ctx context.Context,
+	virtualServer *repositories.VirtualServer,
+	applicationName string,
+	applicationSecret string,
+) (*repositories.Application, error) {
 	scope := middlewares.GetScope(ctx)
 	dbContext := ioc.GetDependency[database.Context](scope)
 
-	applicationFilter := repositories.NewApplicationFilter().Name(applicationName)
+	applicationFilter := repositories.NewApplicationFilter().
+		VirtualServerId(virtualServer.Id()).
+		Name(applicationName)
 	application, err := dbContext.Applications().FirstOrNil(ctx, applicationFilter)
 	if err != nil {
 		return nil, fmt.Errorf("getting application: %w", err)
@@ -874,17 +931,49 @@ func authenticateApplication(ctx context.Context, applicationName string, applic
 		return nil, fmt.Errorf("application not found")
 	}
 
-	if applicationSecret == "" {
-		// TODO: do pkce
+	switch application.Type() {
+	case repositories.ApplicationTypeConfidential:
+		if applicationSecret == "" {
+			return nil, fmt.Errorf("client_secret is required for confidential clients")
+		}
+		if !utils.CheapCompareHash(applicationSecret, application.HashedSecret()) {
+			return nil, fmt.Errorf("invalid secret")
+		}
 		return application, nil
-	}
 
-	hashedSecret := application.HashedSecret()
-	if utils.CheapCompareHash(applicationSecret, hashedSecret) {
+	case repositories.ApplicationTypePublic:
+		if applicationSecret != "" {
+			return nil, fmt.Errorf("public clients must not present a client_secret")
+		}
 		return application, nil
-	}
 
-	return nil, fmt.Errorf("invalid secret")
+	default:
+		return nil, fmt.Errorf("unsupported application type: %s", application.Type())
+	}
+}
+
+// verifyPKCE checks an RFC 7636 PKCE code_verifier against the stored
+// code_challenge and method. Only S256 is accepted; "plain" is rejected since
+// it provides no protection against an attacker who can read the request.
+func verifyPKCE(verifier, challenge, method string) error {
+	if verifier == "" {
+		return fmt.Errorf("code_verifier is required")
+	}
+	// RFC 7636 §4.1: verifier is 43-128 chars, A-Z a-z 0-9 - . _ ~
+	if len(verifier) < 43 || len(verifier) > 128 {
+		return fmt.Errorf("code_verifier length must be between 43 and 128 characters")
+	}
+	switch method {
+	case "S256":
+		sum := sha256.Sum256([]byte(verifier))
+		computed := base64.RawURLEncoding.EncodeToString(sum[:])
+		if subtle.ConstantTimeCompare([]byte(computed), []byte(challenge)) != 1 {
+			return fmt.Errorf("code_verifier does not match code_challenge")
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported code_challenge_method: %s", method)
+	}
 }
 
 type CodeFlowResponse struct {
@@ -928,15 +1017,49 @@ func handleAuthorizationCode(w http.ResponseWriter, r *http.Request) {
 	clientId, clientSecret, hasBasicAuth := r.BasicAuth()
 	if !hasBasicAuth {
 		clientId = r.Form.Get("client_id")
-	}
-
-	_, err = authenticateApplication(ctx, clientId, clientSecret)
-	if err != nil {
-		utils.HandleHttpError(w, fmt.Errorf("authenticating application: %w", err))
-		return
+		clientSecret = r.Form.Get("client_secret")
 	}
 
 	dbContext := ioc.GetDependency[database.Context](scope)
+
+	// Resolve the virtual server from the code itself (not the URL): the code
+	// is what we're trusting; everything else must be validated against it.
+	virtualServerFilter := repositories.NewVirtualServerFilter().Name(codeInfo.VirtualServerName)
+	virtualServer, err := dbContext.VirtualServers().FirstOrNil(ctx, virtualServerFilter)
+	if err != nil {
+		utils.HandleHttpError(w, fmt.Errorf("getting virtual server: %w", err))
+		return
+	}
+	if virtualServer == nil {
+		writeOAuthError(w, "invalid_grant", "virtual server not found")
+		return
+	}
+
+	application, err := authenticateApplication(ctx, virtualServer, clientId, clientSecret)
+	if err != nil {
+		writeOAuthError(w, "invalid_client", err.Error())
+		return
+	}
+
+	// RFC 6749 §4.1.3: the client MUST be the same one the code was issued to.
+	if application.Id() != codeInfo.ApplicationId {
+		writeOAuthError(w, "invalid_grant", "authorization code was issued to a different client")
+		return
+	}
+
+	// RFC 6749 §4.1.3 / §10.6: redirect_uri at /token MUST match what was used at /authorize.
+	if r.Form.Get("redirect_uri") != codeInfo.RedirectUri {
+		writeOAuthError(w, "invalid_grant", "redirect_uri does not match the authorization request")
+		return
+	}
+
+	// RFC 7636: PKCE verifier is required when a challenge was bound to the code.
+	if codeInfo.CodeChallenge != "" {
+		if err := verifyPKCE(r.Form.Get("code_verifier"), codeInfo.CodeChallenge, codeInfo.CodeChallengeMethod); err != nil {
+			writeOAuthError(w, "invalid_grant", err.Error())
+			return
+		}
+	}
 
 	userFilter := repositories.NewUserFilter().Id(codeInfo.UserId)
 	user, err := dbContext.Users().FirstOrNil(ctx, userFilter)
@@ -953,26 +1076,6 @@ func handleAuthorizationCode(w http.ResponseWriter, r *http.Request) {
 
 	clockService := ioc.GetDependency[clock.Service](scope)
 	now := clockService.Now()
-
-	virtualServerFilter := repositories.NewVirtualServerFilter().Name(codeInfo.VirtualServerName)
-	virtualServer, err := dbContext.VirtualServers().FirstOrNil(r.Context(), virtualServerFilter)
-	if err != nil {
-		utils.HandleHttpError(w, fmt.Errorf("getting virtual server: %w", err))
-		return
-	}
-
-	applicationFilter := repositories.NewApplicationFilter().
-		VirtualServerId(virtualServer.Id()).
-		Name(clientId)
-	application, err := dbContext.Applications().FirstOrNil(ctx, applicationFilter)
-	if err != nil {
-		utils.HandleHttpError(w, fmt.Errorf("getting application: %w", err))
-		return
-	}
-	if application == nil {
-		utils.HandleHttpError(w, fmt.Errorf("application not found"))
-		return
-	}
 
 	keyService := ioc.GetDependency[services.KeyService](scope)
 	keyPair, err := keyService.GetKey(codeInfo.VirtualServerName, appSigningAlgorithm(virtualServer, application))
@@ -1354,18 +1457,13 @@ func handleRefreshToken(w http.ResponseWriter, r *http.Request) {
 	clientId, clientSecret, hasBasicAuth := r.BasicAuth()
 	if !hasBasicAuth {
 		clientId = r.Form.Get("client_id")
-	}
-
-	_, err := authenticateApplication(ctx, clientId, clientSecret)
-	if err != nil {
-		utils.HandleHttpError(w, fmt.Errorf("authenticating application: %w", err))
-		return
+		clientSecret = r.Form.Get("client_secret")
 	}
 
 	tokenService := ioc.GetDependency[services.TokenService](scope)
 	refreshTokenInfoString, err := tokenService.GetToken(ctx, services.OidcRefreshTokenTokenType, r.Form.Get("refresh_token"))
 	if err != nil {
-		utils.HandleHttpError(w, fmt.Errorf("getting refresh token: %w", err))
+		writeOAuthError(w, "invalid_grant", "refresh token is invalid or expired")
 		return
 	}
 
@@ -1376,8 +1474,26 @@ func handleRefreshToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	dbContext := ioc.GetDependency[database.Context](scope)
+
+	virtualServerFilter := repositories.NewVirtualServerFilter().Name(refreshTokenInfo.VirtualServerName)
+	virtualServer, err := dbContext.VirtualServers().FirstOrNil(ctx, virtualServerFilter)
+	if err != nil {
+		utils.HandleHttpError(w, fmt.Errorf("getting virtual server: %w", err))
+		return
+	}
+	if virtualServer == nil {
+		writeOAuthError(w, "invalid_grant", "virtual server not found")
+		return
+	}
+
+	if _, err := authenticateApplication(ctx, virtualServer, clientId, clientSecret); err != nil {
+		writeOAuthError(w, "invalid_client", err.Error())
+		return
+	}
+
 	if refreshTokenInfo.ClientId != clientId {
-		writeOAuthError(w, "invalid_grant", "The provided authorization grant (e.g., authorization code, resource owner credentials) or refresh token is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.")
+		writeOAuthError(w, "invalid_grant", "refresh token was issued to a different client")
 		return
 	}
 
@@ -1386,8 +1502,6 @@ func handleRefreshToken(w http.ResponseWriter, r *http.Request) {
 		utils.HandleHttpError(w, fmt.Errorf("deleting refresh token: %w", err))
 		return
 	}
-
-	dbContext := ioc.GetDependency[database.Context](scope)
 
 	userFilter := repositories.NewUserFilter().Id(refreshTokenInfo.UserId)
 	user, err := dbContext.Users().FirstOrNil(ctx, userFilter)
@@ -1402,13 +1516,6 @@ func handleRefreshToken(w http.ResponseWriter, r *http.Request) {
 
 	clockService := ioc.GetDependency[clock.Service](scope)
 	now := clockService.Now()
-
-	virtualServerFilter := repositories.NewVirtualServerFilter().Name(refreshTokenInfo.VirtualServerName)
-	virtualServer, err := dbContext.VirtualServers().FirstOrNil(r.Context(), virtualServerFilter)
-	if err != nil {
-		utils.HandleHttpError(w, fmt.Errorf("getting virtual server: %w", err))
-		return
-	}
 
 	applicationFilter := repositories.NewApplicationFilter().
 		VirtualServerId(virtualServer.Id()).

--- a/internal/handlers/oidc_test.go
+++ b/internal/handlers/oidc_test.go
@@ -2,6 +2,8 @@ package handlers
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
 	"github.com/The127/Keyline/config"
 	"github.com/The127/Keyline/internal/database"
 	"github.com/The127/Keyline/internal/middlewares"
@@ -261,4 +263,66 @@ func TestGenerateRefreshTokenInfo_ReturnsExpectedJSON(t *testing.T) {
 	assert.Contains(t, info, userId.String())
 	assert.Contains(t, info, "test-server")
 	assert.Contains(t, info, "test-client")
+}
+
+// pkceChallenge returns base64url(sha256(verifier)) without padding.
+func pkceChallenge(verifier string) string {
+	sum := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+// 56-char verifier; well within RFC 7636's 43-128 char window.
+const testPkceVerifier = "dummy-verifier-for-poc-do-not-use-in-real-systems-please"
+
+func TestVerifyPKCE_AcceptsCorrectS256Verifier(t *testing.T) {
+	t.Parallel()
+	require.NoError(t, verifyPKCE(testPkceVerifier, pkceChallenge(testPkceVerifier), "S256"))
+}
+
+func TestVerifyPKCE_RejectsWrongVerifier(t *testing.T) {
+	t.Parallel()
+	err := verifyPKCE("wrong-verifier-but-still-long-enough-to-pass-length-check", pkceChallenge(testPkceVerifier), "S256")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "code_verifier does not match")
+}
+
+func TestVerifyPKCE_RejectsEmptyVerifier(t *testing.T) {
+	t.Parallel()
+	err := verifyPKCE("", pkceChallenge(testPkceVerifier), "S256")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "code_verifier is required")
+}
+
+func TestVerifyPKCE_RejectsTooShortVerifier(t *testing.T) {
+	t.Parallel()
+	short := "too-short"
+	err := verifyPKCE(short, pkceChallenge(short), "S256")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "length")
+}
+
+func TestVerifyPKCE_RejectsTooLongVerifier(t *testing.T) {
+	t.Parallel()
+	long := ""
+	for i := 0; i < 129; i++ {
+		long += "a"
+	}
+	err := verifyPKCE(long, pkceChallenge(long), "S256")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "length")
+}
+
+func TestVerifyPKCE_RejectsPlainMethod(t *testing.T) {
+	t.Parallel()
+	// "plain" is no longer accepted because it provides no real protection.
+	err := verifyPKCE(testPkceVerifier, testPkceVerifier, "plain")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported code_challenge_method")
+}
+
+func TestVerifyPKCE_RejectsUnknownMethod(t *testing.T) {
+	t.Parallel()
+	err := verifyPKCE(testPkceVerifier, pkceChallenge(testPkceVerifier), "S512")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported code_challenge_method")
 }

--- a/internal/jsonTypes/CodeInfo.go
+++ b/internal/jsonTypes/CodeInfo.go
@@ -8,18 +8,39 @@ import (
 
 type CodeInfo struct {
 	VirtualServerName string
+	ApplicationId     uuid.UUID
 	GrantedScopes     []string
 	UserId            uuid.UUID
 	Nonce             string
 	AuthenticatedAt   time.Time
+	RedirectUri       string
+	// CodeChallenge and CodeChallengeMethod are populated when the client
+	// initiated the flow with PKCE. If CodeChallenge is empty, no PKCE
+	// verification is required at /token.
+	CodeChallenge       string
+	CodeChallengeMethod string
 }
 
-func NewCodeInfo(virtualServerName string, grantedScopes []string, userId uuid.UUID, nonce string, authenticatedAt time.Time) CodeInfo {
+func NewCodeInfo(
+	virtualServerName string,
+	applicationId uuid.UUID,
+	grantedScopes []string,
+	userId uuid.UUID,
+	nonce string,
+	authenticatedAt time.Time,
+	redirectUri string,
+	codeChallenge string,
+	codeChallengeMethod string,
+) CodeInfo {
 	return CodeInfo{
-		VirtualServerName: virtualServerName,
-		GrantedScopes:     grantedScopes,
-		UserId:            userId,
-		Nonce:             nonce,
-		AuthenticatedAt:   authenticatedAt,
+		VirtualServerName:   virtualServerName,
+		ApplicationId:       applicationId,
+		GrantedScopes:       grantedScopes,
+		UserId:              userId,
+		Nonce:               nonce,
+		AuthenticatedAt:     authenticatedAt,
+		RedirectUri:         redirectUri,
+		CodeChallenge:       codeChallenge,
+		CodeChallengeMethod: codeChallengeMethod,
 	}
 }

--- a/tests/e2e/authcodeflow_test.go
+++ b/tests/e2e/authcodeflow_test.go
@@ -1,0 +1,458 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/The127/Keyline/config"
+	"github.com/The127/Keyline/internal/authentication"
+	"github.com/The127/Keyline/internal/commands"
+	"github.com/The127/Keyline/internal/database"
+	"github.com/The127/Keyline/internal/middlewares"
+	"github.com/The127/Keyline/internal/repositories"
+	"github.com/The127/Keyline/utils"
+
+	"github.com/The127/ioc"
+	"github.com/The127/mediatr"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// Regression tests for the "authorization code is not bound to client/
+// redirect_uri/PKCE" vulnerability. Each scenario drives the full login flow
+// and then exercises one specific check at /token.
+
+const (
+	authCodePublicAppName       = "auth-code-public-app"
+	authCodeConfidentialAppName = "auth-code-confidential-app"
+	authCodeConfidentialSecret  = "test-confidential-secret-for-e2e-do-not-reuse"
+	authCodeRedirect            = "http://localhost:9000/callback"
+	authCodeOtherRedirect       = "http://localhost:9000/other-callback"
+	authCodeUserName            = "auth-code-user"
+	authCodeUserPassword        = "auth-code-user-password-1"
+
+	// 56 chars; in RFC 7636's 43-128 window.
+	authCodePkceVerifier = "regression-test-verifier-do-not-use-in-real-systems-x12"
+)
+
+func authCodePkceChallenge(verifier string) string {
+	sum := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+// authCodeFlow drives /authorize -> /logins/<token>/verify-password -> /finish-login
+// and returns the issued authorization code.
+func authCodeFlow(serverUrl, clientId, redirectUri, codeChallenge string) (string, error) {
+	httpClient := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	authorizeURL := fmt.Sprintf("%s/oidc/test-vs/authorize", serverUrl)
+	q := url.Values{}
+	q.Set("response_type", "code")
+	q.Set("client_id", clientId)
+	q.Set("redirect_uri", redirectUri)
+	q.Set("scope", "openid email profile")
+	q.Set("state", "regression-state")
+	q.Set("nonce", "regression-nonce")
+	q.Set("code_challenge", codeChallenge)
+	q.Set("code_challenge_method", "S256")
+
+	resp, err := httpClient.Get(authorizeURL + "?" + q.Encode())
+	if err != nil {
+		return "", fmt.Errorf("authorize: %w", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusFound {
+		return "", fmt.Errorf("authorize: expected 302, got %d", resp.StatusCode)
+	}
+
+	loc, err := url.Parse(resp.Header.Get("Location"))
+	if err != nil {
+		return "", fmt.Errorf("parsing login redirect: %w", err)
+	}
+	loginToken := loc.Query().Get("token")
+	if loginToken == "" {
+		return "", fmt.Errorf("no login token in /authorize redirect: %s", resp.Header.Get("Location"))
+	}
+
+	credentialsBody := fmt.Sprintf(`{"username":%q,"password":%q}`, authCodeUserName, authCodeUserPassword)
+	resp, err = httpClient.Post(
+		fmt.Sprintf("%s/logins/%s/verify-password", serverUrl, loginToken),
+		"application/json",
+		strings.NewReader(credentialsBody),
+	)
+	if err != nil {
+		return "", fmt.Errorf("verify-password: %w", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("verify-password: status %d: %s", resp.StatusCode, body)
+	}
+
+	resp, err = httpClient.Post(fmt.Sprintf("%s/logins/%s/finish-login", serverUrl, loginToken), "", nil)
+	if err != nil {
+		return "", fmt.Errorf("finish-login: %w", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusFound {
+		return "", fmt.Errorf("finish-login: expected 302, got %d", resp.StatusCode)
+	}
+	cookieHdr := resp.Header.Get("Set-Cookie")
+	if cookieHdr == "" {
+		return "", fmt.Errorf("finish-login: no Set-Cookie")
+	}
+	sessionCookie := strings.SplitN(cookieHdr, ";", 2)[0]
+	nextURL := resp.Header.Get("Location")
+	if !strings.HasPrefix(nextURL, "http") {
+		nextURL = serverUrl + nextURL
+	}
+
+	req, err := http.NewRequest(http.MethodGet, nextURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Cookie", sessionCookie)
+	resp, err = httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("second authorize: %w", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusFound {
+		return "", fmt.Errorf("second authorize: expected 302, got %d", resp.StatusCode)
+	}
+
+	finalURL, err := url.Parse(resp.Header.Get("Location"))
+	if err != nil {
+		return "", fmt.Errorf("parsing final redirect: %w", err)
+	}
+	if errStr := finalURL.Query().Get("error"); errStr != "" {
+		return "", fmt.Errorf("authorize returned error: %s (%s)", errStr, finalURL.Query().Get("error_description"))
+	}
+	code := finalURL.Query().Get("code")
+	if code == "" {
+		return "", fmt.Errorf("no code in final redirect: %s", resp.Header.Get("Location"))
+	}
+	return code, nil
+}
+
+// postToken posts form-encoded params to the token endpoint and returns the parsed JSON.
+func postToken(serverUrl string, form url.Values) (int, map[string]any, error) {
+	resp, err := http.PostForm(fmt.Sprintf("%s/oidc/test-vs/token", serverUrl), form)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp.StatusCode, nil, err
+	}
+	parsed := map[string]any{}
+	_ = json.Unmarshal(body, &parsed)
+	return resp.StatusCode, parsed, nil
+}
+
+func init() {
+	for _, backend := range testBackends {
+		backend := backend
+		Describe("Authorization Code Flow regression ["+backend.name+"]", Ordered, func() {
+			var h *harness
+
+			BeforeAll(func() {
+				if backend.dbMode == config.DatabaseModePostgres && !postgresBackendAvailable() {
+					Skip("Postgres not available")
+				}
+				h = newE2eTestHarness(backend.dbMode, nil)
+				Expect(setupAuthCodeFixtures(h.Scope())).To(Succeed())
+			})
+
+			AfterAll(func() {
+				if h != nil {
+					h.Close()
+				}
+			})
+
+			Describe("/authorize", func() {
+				It("rejects requests without a code_challenge", func() {
+					httpClient := &http.Client{
+						CheckRedirect: func(req *http.Request, via []*http.Request) error {
+							return http.ErrUseLastResponse
+						},
+					}
+					q := url.Values{}
+					q.Set("response_type", "code")
+					q.Set("client_id", authCodePublicAppName)
+					q.Set("redirect_uri", authCodeRedirect)
+					q.Set("scope", "openid")
+					resp, err := httpClient.Get(fmt.Sprintf("%s/oidc/test-vs/authorize?%s", h.ApiUrl(), q.Encode()))
+					Expect(err).ToNot(HaveOccurred())
+					resp.Body.Close()
+					// Errors are reported by redirecting to the redirect_uri with ?error=...
+					Expect(resp.StatusCode).To(Equal(http.StatusFound))
+					loc, err := url.Parse(resp.Header.Get("Location"))
+					Expect(err).ToNot(HaveOccurred())
+					Expect(loc.Query().Get("error")).To(Equal("invalid_request"))
+				})
+
+				It("rejects code_challenge_method=plain", func() {
+					httpClient := &http.Client{
+						CheckRedirect: func(req *http.Request, via []*http.Request) error {
+							return http.ErrUseLastResponse
+						},
+					}
+					q := url.Values{}
+					q.Set("response_type", "code")
+					q.Set("client_id", authCodePublicAppName)
+					q.Set("redirect_uri", authCodeRedirect)
+					q.Set("scope", "openid")
+					q.Set("code_challenge", authCodePkceVerifier)
+					q.Set("code_challenge_method", "plain")
+					resp, err := httpClient.Get(fmt.Sprintf("%s/oidc/test-vs/authorize?%s", h.ApiUrl(), q.Encode()))
+					Expect(err).ToNot(HaveOccurred())
+					resp.Body.Close()
+					Expect(resp.StatusCode).To(Equal(http.StatusFound))
+					loc, err := url.Parse(resp.Header.Get("Location"))
+					Expect(err).ToNot(HaveOccurred())
+					Expect(loc.Query().Get("error")).To(Equal("invalid_request"))
+				})
+			})
+
+			Describe("/token authorization_code", func() {
+				It("legitimate redemption with PKCE verifier succeeds", func() {
+					code, err := authCodeFlow(h.ApiUrl(), authCodePublicAppName, authCodeRedirect, authCodePkceChallenge(authCodePkceVerifier))
+					Expect(err).ToNot(HaveOccurred())
+
+					form := url.Values{}
+					form.Set("grant_type", "authorization_code")
+					form.Set("code", code)
+					form.Set("client_id", authCodePublicAppName)
+					form.Set("redirect_uri", authCodeRedirect)
+					form.Set("code_verifier", authCodePkceVerifier)
+
+					status, body, err := postToken(h.ApiUrl(), form)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(status).To(Equal(http.StatusOK), fmt.Sprintf("body: %v", body))
+					Expect(body["access_token"]).ToNot(BeNil())
+				})
+
+				It("rejects when code_verifier is missing (REGRESSION: PKCE bypass)", func() {
+					code, err := authCodeFlow(h.ApiUrl(), authCodePublicAppName, authCodeRedirect, authCodePkceChallenge(authCodePkceVerifier))
+					Expect(err).ToNot(HaveOccurred())
+
+					form := url.Values{}
+					form.Set("grant_type", "authorization_code")
+					form.Set("code", code)
+					form.Set("client_id", authCodePublicAppName)
+					form.Set("redirect_uri", authCodeRedirect)
+					// NO code_verifier
+					status, body, err := postToken(h.ApiUrl(), form)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(status).To(Equal(http.StatusBadRequest))
+					Expect(body["error"]).To(Equal("invalid_grant"))
+				})
+
+				It("rejects a wrong code_verifier (REGRESSION: PKCE not actually checked)", func() {
+					code, err := authCodeFlow(h.ApiUrl(), authCodePublicAppName, authCodeRedirect, authCodePkceChallenge(authCodePkceVerifier))
+					Expect(err).ToNot(HaveOccurred())
+
+					form := url.Values{}
+					form.Set("grant_type", "authorization_code")
+					form.Set("code", code)
+					form.Set("client_id", authCodePublicAppName)
+					form.Set("redirect_uri", authCodeRedirect)
+					form.Set("code_verifier", "this-verifier-is-wrong-but-still-the-right-length-okay")
+
+					status, body, err := postToken(h.ApiUrl(), form)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(status).To(Equal(http.StatusBadRequest))
+					Expect(body["error"]).To(Equal("invalid_grant"))
+				})
+
+				It("rejects redemption with a different client_id (REGRESSION: code/client binding)", func() {
+					code, err := authCodeFlow(h.ApiUrl(), authCodePublicAppName, authCodeRedirect, authCodePkceChallenge(authCodePkceVerifier))
+					Expect(err).ToNot(HaveOccurred())
+
+					form := url.Values{}
+					form.Set("grant_type", "authorization_code")
+					form.Set("code", code)
+					// Code was issued to public app; redeem as the confidential app, fully authenticated.
+					form.Set("client_id", authCodeConfidentialAppName)
+					form.Set("client_secret", authCodeConfidentialSecret)
+					form.Set("redirect_uri", authCodeRedirect)
+					form.Set("code_verifier", authCodePkceVerifier)
+
+					status, body, err := postToken(h.ApiUrl(), form)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(status).To(Equal(http.StatusBadRequest))
+					Expect(body["error"]).To(Equal("invalid_grant"))
+				})
+
+				It("rejects a mismatched redirect_uri (REGRESSION: code/redirect binding)", func() {
+					code, err := authCodeFlow(h.ApiUrl(), authCodePublicAppName, authCodeRedirect, authCodePkceChallenge(authCodePkceVerifier))
+					Expect(err).ToNot(HaveOccurred())
+
+					form := url.Values{}
+					form.Set("grant_type", "authorization_code")
+					form.Set("code", code)
+					form.Set("client_id", authCodePublicAppName)
+					form.Set("redirect_uri", authCodeOtherRedirect) // different from /authorize
+					form.Set("code_verifier", authCodePkceVerifier)
+
+					status, body, err := postToken(h.ApiUrl(), form)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(status).To(Equal(http.StatusBadRequest))
+					Expect(body["error"]).To(Equal("invalid_grant"))
+				})
+
+				It("rejects confidential client with empty client_secret (REGRESSION: empty-secret bypass)", func() {
+					// Code is issued to the confidential client; we then try to redeem
+					// it without the secret. Pre-fix this returned tokens.
+					code, err := authCodeFlow(h.ApiUrl(), authCodeConfidentialAppName, authCodeRedirect, authCodePkceChallenge(authCodePkceVerifier))
+					Expect(err).ToNot(HaveOccurred())
+
+					form := url.Values{}
+					form.Set("grant_type", "authorization_code")
+					form.Set("code", code)
+					form.Set("client_id", authCodeConfidentialAppName)
+					form.Set("redirect_uri", authCodeRedirect)
+					form.Set("code_verifier", authCodePkceVerifier)
+					// NO client_secret
+
+					status, body, err := postToken(h.ApiUrl(), form)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(status).To(Equal(http.StatusBadRequest))
+					Expect(body["error"]).To(Equal("invalid_client"))
+				})
+
+				It("rejects confidential client with wrong client_secret", func() {
+					code, err := authCodeFlow(h.ApiUrl(), authCodeConfidentialAppName, authCodeRedirect, authCodePkceChallenge(authCodePkceVerifier))
+					Expect(err).ToNot(HaveOccurred())
+
+					form := url.Values{}
+					form.Set("grant_type", "authorization_code")
+					form.Set("code", code)
+					form.Set("client_id", authCodeConfidentialAppName)
+					form.Set("client_secret", "the-wrong-secret-here-it-is-not-correct")
+					form.Set("redirect_uri", authCodeRedirect)
+					form.Set("code_verifier", authCodePkceVerifier)
+
+					status, body, err := postToken(h.ApiUrl(), form)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(status).To(Equal(http.StatusBadRequest))
+					Expect(body["error"]).To(Equal("invalid_client"))
+				})
+
+				It("rejects public client redemption that includes a client_secret", func() {
+					code, err := authCodeFlow(h.ApiUrl(), authCodePublicAppName, authCodeRedirect, authCodePkceChallenge(authCodePkceVerifier))
+					Expect(err).ToNot(HaveOccurred())
+
+					form := url.Values{}
+					form.Set("grant_type", "authorization_code")
+					form.Set("code", code)
+					form.Set("client_id", authCodePublicAppName)
+					form.Set("client_secret", "anything-since-public-clients-have-no-secret")
+					form.Set("redirect_uri", authCodeRedirect)
+					form.Set("code_verifier", authCodePkceVerifier)
+
+					status, body, err := postToken(h.ApiUrl(), form)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(status).To(Equal(http.StatusBadRequest))
+					Expect(body["error"]).To(Equal("invalid_client"))
+				})
+			})
+		})
+	}
+}
+
+func setupAuthCodeFixtures(scope *ioc.DependencyProvider) error {
+	subscope := scope.NewScope()
+	defer subscope.Close()
+
+	ctx := context.Background()
+	ctx = middlewares.ContextWithScope(ctx, subscope)
+	ctx = authentication.ContextWithCurrentUser(ctx, authentication.SystemUser())
+
+	m := ioc.GetDependency[mediatr.Mediator](subscope)
+	dbContext := ioc.GetDependency[database.Context](subscope)
+
+	if _, err := mediatr.Send[*commands.CreateProjectResponse](ctx, m, commands.CreateProject{
+		VirtualServerName: "test-vs",
+		Slug:              "auth-code-project",
+		Name:              "Auth Code Project",
+	}); err != nil {
+		return fmt.Errorf("creating project: %w", err)
+	}
+	if err := dbContext.SaveChanges(ctx); err != nil {
+		return err
+	}
+
+	if _, err := mediatr.Send[*commands.CreateApplicationResponse](ctx, m, commands.CreateApplication{
+		VirtualServerName:      "test-vs",
+		ProjectSlug:            "auth-code-project",
+		Name:                   authCodePublicAppName,
+		DisplayName:            "Auth Code Public App",
+		Type:                   repositories.ApplicationTypePublic,
+		RedirectUris:           []string{authCodeRedirect, authCodeOtherRedirect},
+		PostLogoutRedirectUris: []string{},
+	}); err != nil {
+		return fmt.Errorf("creating public app: %w", err)
+	}
+	if err := dbContext.SaveChanges(ctx); err != nil {
+		return err
+	}
+
+	if _, err := mediatr.Send[*commands.CreateApplicationResponse](ctx, m, commands.CreateApplication{
+		VirtualServerName:      "test-vs",
+		ProjectSlug:            "auth-code-project",
+		Name:                   authCodeConfidentialAppName,
+		DisplayName:            "Auth Code Confidential App",
+		Type:                   repositories.ApplicationTypeConfidential,
+		HashedSecret:           utils.Ptr(utils.CheapHash(authCodeConfidentialSecret)),
+		RedirectUris:           []string{authCodeRedirect, authCodeOtherRedirect},
+		PostLogoutRedirectUris: []string{},
+	}); err != nil {
+		return fmt.Errorf("creating confidential app: %w", err)
+	}
+	if err := dbContext.SaveChanges(ctx); err != nil {
+		return err
+	}
+
+	userResp, err := mediatr.Send[*commands.CreateUserResponse](ctx, m, commands.CreateUser{
+		VirtualServerName: "test-vs",
+		DisplayName:       "Auth Code User",
+		Username:          authCodeUserName,
+		Email:             authCodeUserName + "@test.local",
+		EmailVerified:     true,
+	})
+	if err != nil {
+		return fmt.Errorf("creating user: %w", err)
+	}
+	if err := dbContext.SaveChanges(ctx); err != nil {
+		return err
+	}
+
+	cred := repositories.NewCredential(userResp.Id, &repositories.CredentialPasswordDetails{
+		HashedPassword: utils.HashPassword(authCodeUserPassword),
+		Temporary:      false,
+	})
+	dbContext.Credentials().Insert(cred)
+	if err := dbContext.SaveChanges(ctx); err != nil {
+		return err
+	}
+
+	_ = uuid.Nil // keep uuid import
+	return nil
+}


### PR DESCRIPTION
## Summary

Closes a critical OAuth 2.0 authorization-code injection: a single leaked authorization code was enough to take over the issuing user's account against any client in the same virtual server, with no client_secret and no PKCE verifier needed.

Three independent gaps combined into the bug:

- `CodeInfo` only persisted user/scope/nonce. It did not carry `client_id`, `redirect_uri`, or `code_challenge`, so the token endpoint had nothing to compare requests against.
- `authenticateApplication` looked up applications by name only (no virtual server filter) and short-circuited to success when `client_secret` was empty (`// TODO: do pkce`).
- `handleAuthorizationCode` never compared `client_id`, `redirect_uri`, or any `code_verifier` against the code.

A local PoC (Python script, runs against `docker compose up`'d dev deps) reproduced both `EXPLOIT A` (PKCE verifier not required) and `EXPLOIT B` (code redeemed at a different client) with HTTP 200 + signed tokens.

## What changed

- `internal/jsonTypes/CodeInfo.go` -- adds `ApplicationId`, `RedirectUri`, `CodeChallenge`, `CodeChallengeMethod`. `NewCodeInfo` requires them.
- `internal/handlers/oidc.go`
  - `BeginAuthorizationFlow` now requires `code_challenge` with `code_challenge_method=S256` (`plain` rejected -- no real protection).
  - `authenticateApplication` rewritten: virtual-server-scoped lookup, confidential clients must present a matching non-empty `client_secret`, public clients must not present one (their proof of possession is the PKCE verifier).
  - New helper `verifyPKCE`: S256 only, RFC 7636 length window, constant-time compare.
  - `handleAuthorizationCode` enforces three independent gates after authentication: `application.Id() == codeInfo.ApplicationId`, exact `redirect_uri` match, PKCE verifier check.
  - `handleRefreshToken` is on the same `authenticateApplication` so the empty-secret bypass no longer applies there either.

## Compatibility note

Public clients that did not previously send PKCE will now be rejected at `/authorize`. This is OAuth 2.1 guidance and necessary to close the bug for public clients. Confidential client integrations are unaffected as long as they were sending a real `client_secret` (which they were required to do in any RFC-conformant integration).

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/handlers/` -- existing + 7 new `TestVerifyPKCE_*` cases pass
- [x] `just e2e` -- 88/88 specs pass on both Postgres and memory backends, including the new "Authorization Code Flow regression" describe block (10 specs covering each gate plus the happy path)
- [x] Local PoC blocks both `EXPLOIT A` (`code_verifier is required`) and `EXPLOIT B` (`authorization code was issued to a different client`); legitimate flow still issues real tokens

## Out of scope, worth filing as separate issues

- `handleDeviceCodeGrant` (`internal/handlers/oidc.go:~1849`) explicitly discards `client_secret` for confidential clients -- same family of bug, distinct codepath.
- `BeginAuthorizationFlow`'s `request` parameter (`internal/handlers/oidc.go:~332`) uses `ParseUnverified` and overrides incoming params with unsigned JWT claims -- OIDC requires signature verification.