### PR TITLE
fix(oidc): authenticate clients on the device authorization grant

### DIFF
--- a/internal/handlers/oidc.go
+++ b/internal/handlers/oidc.go
@@ -1856,7 +1856,11 @@ func BeginDeviceFlow(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	clientId := r.Form.Get("client_id")
+	clientId, clientSecret, hasBasicAuth := r.BasicAuth()
+	if !hasBasicAuth {
+		clientId = r.Form.Get("client_id")
+		clientSecret = r.Form.Get("client_secret")
+	}
 	if clientId == "" {
 		writeOAuthError(w, "invalid_client", "client_id is required")
 		return
@@ -1883,16 +1887,11 @@ func BeginDeviceFlow(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	applicationFilter := repositories.NewApplicationFilter().
-		VirtualServerId(virtualServer.Id()).
-		Name(clientId)
-	application, err := dbContext.Applications().FirstOrNil(ctx, applicationFilter)
+	// RFC 8628 §3.1: confidential clients MUST authenticate at the device
+	// authorization endpoint per RFC 6749 §3.2.1.
+	application, err := authenticateApplication(ctx, virtualServer, clientId, clientSecret)
 	if err != nil {
-		utils.HandleHttpError(w, fmt.Errorf("getting application: %w", err))
-		return
-	}
-	if application == nil {
-		writeOAuthError(w, "invalid_client", "application not found")
+		writeOAuthError(w, "invalid_client", err.Error())
 		return
 	}
 
@@ -1960,7 +1959,7 @@ func handleDeviceCodeGrant(w http.ResponseWriter, r *http.Request) {
 	clientId, clientSecret, hasBasicAuth := r.BasicAuth()
 	if !hasBasicAuth {
 		clientId = r.Form.Get("client_id")
-		clientSecret = ""
+		clientSecret = r.Form.Get("client_secret")
 	}
 
 	deviceCode := r.Form.Get("device_code")
@@ -1997,8 +1996,33 @@ func handleDeviceCodeGrant(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	dbContext := ioc.GetDependency[database.Context](scope)
+
+	virtualServerFilter := repositories.NewVirtualServerFilter().Name(deviceCodeInfo.VirtualServerName)
+	virtualServer, err := dbContext.VirtualServers().FirstOrNil(ctx, virtualServerFilter)
+	if err != nil {
+		utils.HandleHttpError(w, fmt.Errorf("getting virtual server: %w", err))
+		return
+	}
+	if virtualServer == nil {
+		writeOAuthError(w, "invalid_grant", "virtual server not found")
+		return
+	}
+
+	// RFC 8628 §3.4: confidential clients MUST authenticate at the token
+	// endpoint per RFC 6749 §3.2.1. authenticateApplication enforces the
+	// per-type rules (confidential => secret required and verified, public =>
+	// no secret allowed) and scopes the lookup to the virtual server.
+	application, err := authenticateApplication(ctx, virtualServer, clientId, clientSecret)
+	if err != nil {
+		writeOAuthError(w, "invalid_client", err.Error())
+		return
+	}
+
+	// Bind the device_code to the client it was issued to. Mirrors the
+	// client_id binding check on the auth-code grant.
 	if deviceCodeInfo.ClientId != clientId {
-		writeOAuthError(w, "invalid_client", "client_id mismatch")
+		writeOAuthError(w, "invalid_grant", "device code was issued to a different client")
 		return
 	}
 
@@ -2014,34 +2038,6 @@ func handleDeviceCodeGrant(w http.ResponseWriter, r *http.Request) {
 		utils.HandleHttpError(w, fmt.Errorf("deleting device code: %w", err))
 		return
 	}
-
-	dbContext := ioc.GetDependency[database.Context](scope)
-
-	virtualServerFilter := repositories.NewVirtualServerFilter().Name(deviceCodeInfo.VirtualServerName)
-	virtualServer, err := dbContext.VirtualServers().FirstOrNil(ctx, virtualServerFilter)
-	if err != nil {
-		utils.HandleHttpError(w, fmt.Errorf("getting virtual server: %w", err))
-		return
-	}
-	if virtualServer == nil {
-		utils.HandleHttpError(w, fmt.Errorf("virtual server not found"))
-		return
-	}
-
-	applicationFilter := repositories.NewApplicationFilter().
-		VirtualServerId(virtualServer.Id()).
-		Name(clientId)
-	application, err := dbContext.Applications().FirstOrNil(ctx, applicationFilter)
-	if err != nil {
-		utils.HandleHttpError(w, fmt.Errorf("getting application: %w", err))
-		return
-	}
-	if application == nil {
-		utils.HandleHttpError(w, fmt.Errorf("application not found"))
-		return
-	}
-
-	_ = clientSecret // public clients don't need a secret
 
 	userFilter := repositories.NewUserFilter().Id(userId)
 	user, err := dbContext.Users().FirstOrNil(ctx, userFilter)

--- a/tests/e2e/deviceflowclientauth_test.go
+++ b/tests/e2e/deviceflowclientauth_test.go
@@ -1,0 +1,317 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/The127/Keyline/config"
+	"github.com/The127/Keyline/internal/authentication"
+	"github.com/The127/Keyline/internal/commands"
+	"github.com/The127/Keyline/internal/database"
+	"github.com/The127/Keyline/internal/middlewares"
+	"github.com/The127/Keyline/internal/repositories"
+	"github.com/The127/Keyline/utils"
+
+	"github.com/The127/ioc"
+	"github.com/The127/mediatr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	devAuthConfClient = "test-device-conf-app"
+	devAuthPubClient  = "test-device-pub-app"
+	devAuthUser       = "test-device-auth-user"
+	devAuthPassword   = "test-device-auth-password-1"
+)
+
+func init() {
+	for _, backend := range testBackends {
+		backend := backend
+		Describe("Device flow client authentication ["+backend.name+"]", Ordered, func() {
+			var h *harness
+			var confSecret string
+
+			BeforeAll(func() {
+				if backend.dbMode == config.DatabaseModePostgres && !postgresBackendAvailable() {
+					Skip("Postgres not available")
+				}
+				h = newE2eTestHarness(backend.dbMode, nil)
+				var err error
+				confSecret, err = setupDeviceFlowClientAuthFixtures(h.Scope())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(confSecret).ToNot(BeEmpty())
+			})
+
+			AfterAll(func() {
+				if h != nil {
+					h.Close()
+				}
+			})
+
+			postForm := func(path string, form url.Values) (int, map[string]any) {
+				req, err := http.NewRequest(http.MethodPost, h.ApiUrl()+path, strings.NewReader(form.Encode()))
+				Expect(err).ToNot(HaveOccurred())
+				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+				resp, err := http.DefaultClient.Do(req)
+				Expect(err).ToNot(HaveOccurred())
+				defer resp.Body.Close() //nolint:errcheck
+
+				body, _ := io.ReadAll(resp.Body)
+				var parsed map[string]any
+				_ = json.Unmarshal(body, &parsed)
+				return resp.StatusCode, parsed
+			}
+
+			postDevice := func(form url.Values) (int, map[string]any) {
+				return postForm("/oidc/test-vs/device", form)
+			}
+
+			postToken := func(form url.Values) (int, map[string]any) {
+				return postForm("/oidc/test-vs/token", form)
+			}
+
+			beginDeviceFlowAuthorized := func(clientId, secret string) (deviceCode, userCode string) {
+				form := url.Values{
+					"client_id": {clientId},
+					"scope":     {"openid"},
+				}
+				if secret != "" {
+					form.Set("client_secret", secret)
+				}
+				status, body := postDevice(form)
+				Expect(status).To(Equal(http.StatusOK), "begin /device for %s should succeed: %v", clientId, body)
+				dc, _ := body["device_code"].(string)
+				uc, _ := body["user_code"].(string)
+				Expect(dc).ToNot(BeEmpty())
+				Expect(uc).ToNot(BeEmpty())
+
+				loginToken, err := h.Client().Oidc().PostActivate(h.Ctx(), uc)
+				Expect(err).ToNot(HaveOccurred())
+				err = h.Client().Oidc().VerifyPassword(h.Ctx(), loginToken, devAuthUser, devAuthPassword)
+				Expect(err).ToNot(HaveOccurred())
+				err = h.Client().Oidc().FinishLogin(h.Ctx(), loginToken)
+				Expect(err).ToNot(HaveOccurred())
+
+				return dc, uc
+			}
+
+			Describe("/device endpoint", func() {
+				It("rejects confidential client without a client_secret", func() {
+					status, body := postDevice(url.Values{
+						"client_id": {devAuthConfClient},
+						"scope":     {"openid"},
+					})
+					Expect(status).To(Equal(http.StatusBadRequest))
+					Expect(body["error"]).To(Equal("invalid_client"))
+				})
+
+				It("rejects confidential client with a wrong client_secret", func() {
+					status, body := postDevice(url.Values{
+						"client_id":     {devAuthConfClient},
+						"client_secret": {"not-the-real-secret"},
+						"scope":         {"openid"},
+					})
+					Expect(status).To(Equal(http.StatusBadRequest))
+					Expect(body["error"]).To(Equal("invalid_client"))
+				})
+
+				It("rejects public client when a client_secret is presented", func() {
+					status, body := postDevice(url.Values{
+						"client_id":     {devAuthPubClient},
+						"client_secret": {"any-value"},
+						"scope":         {"openid"},
+					})
+					Expect(status).To(Equal(http.StatusBadRequest))
+					Expect(body["error"]).To(Equal("invalid_client"))
+				})
+
+				It("accepts confidential client with the correct client_secret", func() {
+					status, body := postDevice(url.Values{
+						"client_id":     {devAuthConfClient},
+						"client_secret": {confSecret},
+						"scope":         {"openid"},
+					})
+					Expect(status).To(Equal(http.StatusOK))
+					Expect(body["device_code"]).ToNot(BeEmpty())
+					Expect(body["user_code"]).ToNot(BeEmpty())
+				})
+
+				It("accepts public client without a client_secret", func() {
+					status, body := postDevice(url.Values{
+						"client_id": {devAuthPubClient},
+						"scope":     {"openid"},
+					})
+					Expect(status).To(Equal(http.StatusOK))
+					Expect(body["device_code"]).ToNot(BeEmpty())
+					Expect(body["user_code"]).ToNot(BeEmpty())
+				})
+			})
+
+			Describe("/token (device_code grant)", func() {
+				It("rejects confidential client redemption without client_secret", func() {
+					deviceCode, _ := beginDeviceFlowAuthorized(devAuthConfClient, confSecret)
+
+					status, body := postToken(url.Values{
+						"grant_type":  {"urn:ietf:params:oauth:grant-type:device_code"},
+						"client_id":   {devAuthConfClient},
+						"device_code": {deviceCode},
+					})
+					Expect(status).To(Equal(http.StatusBadRequest))
+					Expect(body["error"]).To(Equal("invalid_client"))
+				})
+
+				It("rejects confidential client redemption with wrong client_secret", func() {
+					deviceCode, _ := beginDeviceFlowAuthorized(devAuthConfClient, confSecret)
+
+					status, body := postToken(url.Values{
+						"grant_type":    {"urn:ietf:params:oauth:grant-type:device_code"},
+						"client_id":     {devAuthConfClient},
+						"client_secret": {"wrong-secret"},
+						"device_code":   {deviceCode},
+					})
+					Expect(status).To(Equal(http.StatusBadRequest))
+					Expect(body["error"]).To(Equal("invalid_client"))
+				})
+
+				It("rejects public client redemption that includes a client_secret", func() {
+					deviceCode, _ := beginDeviceFlowAuthorized(devAuthPubClient, "")
+
+					status, body := postToken(url.Values{
+						"grant_type":    {"urn:ietf:params:oauth:grant-type:device_code"},
+						"client_id":     {devAuthPubClient},
+						"client_secret": {"unexpected"},
+						"device_code":   {deviceCode},
+					})
+					Expect(status).To(Equal(http.StatusBadRequest))
+					Expect(body["error"]).To(Equal("invalid_client"))
+				})
+
+				It("accepts confidential client redemption with the correct client_secret", func() {
+					deviceCode, _ := beginDeviceFlowAuthorized(devAuthConfClient, confSecret)
+
+					status, body := postToken(url.Values{
+						"grant_type":    {"urn:ietf:params:oauth:grant-type:device_code"},
+						"client_id":     {devAuthConfClient},
+						"client_secret": {confSecret},
+						"device_code":   {deviceCode},
+					})
+					Expect(status).To(Equal(http.StatusOK))
+					Expect(body["access_token"]).ToNot(BeNil())
+					Expect(body["id_token"]).ToNot(BeNil())
+				})
+
+				It("rejects redemption with a different client_id than the device_code was issued to", func() {
+					// device_code issued to the confidential client; attacker tries
+					// to redeem it as the public client (which would pass the
+					// no-secret authentication check). The code/client binding
+					// must reject this.
+					deviceCode, _ := beginDeviceFlowAuthorized(devAuthConfClient, confSecret)
+
+					status, body := postToken(url.Values{
+						"grant_type":  {"urn:ietf:params:oauth:grant-type:device_code"},
+						"client_id":   {devAuthPubClient},
+						"device_code": {deviceCode},
+					})
+					Expect(status).To(Equal(http.StatusBadRequest))
+					Expect(body["error"]).To(Equal("invalid_grant"))
+				})
+			})
+		})
+	}
+}
+
+func setupDeviceFlowClientAuthFixtures(scope *ioc.DependencyProvider) (string, error) {
+	subscope := scope.NewScope()
+	defer subscope.Close()
+
+	ctx := context.Background()
+	ctx = middlewares.ContextWithScope(ctx, subscope)
+	ctx = authentication.ContextWithCurrentUser(ctx, authentication.SystemUser())
+
+	m := ioc.GetDependency[mediatr.Mediator](subscope)
+	dbContext := ioc.GetDependency[database.Context](subscope)
+
+	_, err := mediatr.Send[*commands.CreateProjectResponse](ctx, m, commands.CreateProject{
+		VirtualServerName: "test-vs",
+		Slug:              "device-flow-clientauth-project",
+		Name:              "Device Flow Client Auth Project",
+	})
+	if err != nil {
+		return "", fmt.Errorf("creating project: %w", err)
+	}
+	if err := dbContext.SaveChanges(ctx); err != nil {
+		return "", fmt.Errorf("saving project: %w", err)
+	}
+
+	confResp, err := mediatr.Send[*commands.CreateApplicationResponse](ctx, m, commands.CreateApplication{
+		VirtualServerName:      "test-vs",
+		ProjectSlug:            "device-flow-clientauth-project",
+		Name:                   devAuthConfClient,
+		DisplayName:            "Test Device Confidential App",
+		Type:                   repositories.ApplicationTypeConfidential,
+		RedirectUris:           []string{"http://localhost:9999/callback"},
+		PostLogoutRedirectUris: []string{},
+		DeviceFlowEnabled:      true,
+	})
+	if err != nil {
+		return "", fmt.Errorf("creating confidential application: %w", err)
+	}
+	if err := dbContext.SaveChanges(ctx); err != nil {
+		return "", fmt.Errorf("saving confidential application: %w", err)
+	}
+	if confResp.Secret == nil {
+		return "", fmt.Errorf("confidential client created without a secret")
+	}
+	confSecret := *confResp.Secret
+
+	_, err = mediatr.Send[*commands.CreateApplicationResponse](ctx, m, commands.CreateApplication{
+		VirtualServerName:      "test-vs",
+		ProjectSlug:            "device-flow-clientauth-project",
+		Name:                   devAuthPubClient,
+		DisplayName:            "Test Device Public App",
+		Type:                   repositories.ApplicationTypePublic,
+		RedirectUris:           []string{"http://localhost:9999/callback"},
+		PostLogoutRedirectUris: []string{},
+		DeviceFlowEnabled:      true,
+	})
+	if err != nil {
+		return "", fmt.Errorf("creating public application: %w", err)
+	}
+	if err := dbContext.SaveChanges(ctx); err != nil {
+		return "", fmt.Errorf("saving public application: %w", err)
+	}
+
+	userResp, err := mediatr.Send[*commands.CreateUserResponse](ctx, m, commands.CreateUser{
+		VirtualServerName: "test-vs",
+		DisplayName:       "Test Device Auth User",
+		Username:          devAuthUser,
+		Email:             devAuthUser + "@test.local",
+		EmailVerified:     true,
+	})
+	if err != nil {
+		return "", fmt.Errorf("creating user: %w", err)
+	}
+	if err := dbContext.SaveChanges(ctx); err != nil {
+		return "", fmt.Errorf("saving user: %w", err)
+	}
+
+	passwordCred := repositories.NewCredential(userResp.Id, &repositories.CredentialPasswordDetails{
+		HashedPassword: utils.HashPassword(devAuthPassword),
+		Temporary:      false,
+	})
+	dbContext.Credentials().Insert(passwordCred)
+	if err := dbContext.SaveChanges(ctx); err != nil {
+		return "", fmt.Errorf("saving password credential: %w", err)
+	}
+
+	return confSecret, nil
+}


### PR DESCRIPTION
## Summary

- The OAuth 2.0 Device Authorization Grant (RFC 8628) endpoints were skipping client authentication entirely. A confidential client registered for device flow had **zero protection from its `client_secret`**: anyone with the public `client_id` could start a flow, phish a `user_code` to a victim, and redeem the `device_code` for tokens issued to the impersonated client.
- `BeginDeviceFlow` ignored `client_secret` entirely (no Basic-auth parse, no form read), in violation of RFC 8628 §3.1 + RFC 6749 §3.2.1.
- `handleDeviceCodeGrant` force-zeroed the form-posted `client_secret` and never called `authenticateApplication` — the only check tying the request to the stored device-code info was a string equality on `client_id`, both sides attacker-controlled. Violates RFC 8628 §3.4.

## What changed

- `internal/handlers/oidc.go` — `BeginDeviceFlow`: parse Basic auth + form `client_secret`, route through the existing `authenticateApplication(ctx, virtualServer, clientId, clientSecret)` helper that PR #279 introduced. The helper enforces per-type rules (confidential ⇒ non-empty matching secret required, public ⇒ no secret allowed) and scopes the lookup to the virtual server.
- `internal/handlers/oidc.go` — `handleDeviceCodeGrant`: stop hard-coding `clientSecret = ""`; read it from form. Resolve the virtual server from the stored device-code info, then call `authenticateApplication`. Move the `deviceCodeInfo.ClientId != clientId` binding check to *after* authentication and switch its error code from `invalid_client` to `invalid_grant` (it's a code/client mismatch, not a credential failure). Drop the `_ = clientSecret` line.
- `tests/e2e/deviceflowclientauth_test.go` — new Ginkgo describe block, `e2e` build tag, runs against both backends.

No new helper introduced, no struct changes, no schema or migration changes. The fix mirrors the shape of #279 for a different grant type, reusing the helper that PR added.

## Compatibility notes

- **Confidential device-flow clients now MUST present their `client_secret`** at both `/oidc/{vs}/device` and `/oidc/{vs}/token` (Basic auth or form). Pre-fix, the server accepted them with no secret at all — any integration relying on that behavior was riding on an authentication bypass and will start receiving `invalid_client`.
- **Public device-flow clients now MUST NOT present a `client_secret`** (this matches the same rule already enforced on the auth-code grant after #279).
- The `client_id` mismatch error on the device-code grant changed from `invalid_client` to `invalid_grant`, which is the spec-correct code for a token/client binding mismatch.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/handlers/` — passes (no new pure helper, so no new unit tests; the existing `verifyPKCE` and token-generation suites still pass)
- [x] `go test -tags=e2e ./tests/e2e/` — 108/108 specs pass on both Postgres and memory; the new "Device flow client authentication" describe contributes 10 specs × 2 backends = 20 specs covering both EXPLOIT regressions, the wrong-secret variants, the public-with-secret rejection, both happy paths, and the code/client binding check.
- [x] `golangci-lint run` — 0 issues.
- [x] Out-of-tree PoC at `security_issues/device-flow-no-client-auth/` (in a sibling repo) reproduces both EXPLOITs pre-fix and verifies they're blocked post-fix while both POSITIVE flows still work end-to-end against a local docker-compose Keyline.

## Out of scope (spotted but not in this PR)

- No rate-limit / `slow_down` enforcement on `/token` device_code polling (RFC 8628 §3.5).
- `user_code` entropy is 26^8 ≈ 37.6 bits over a 10-minute window — adequate against single brute force, fragile if multiple codes are concurrently active. Consider tightening at the verification UI with attempt limiting.
- No login-flow brute-force protection on `/logins/<token>/verify-password`.
- Tracked in `security_issues/TODO.md` in the sibling working tree.