### PR TITLE
fix(login): cap failed password attempts per login session token

### DIFF
--- a/internal/handlers/login.go
+++ b/internal/handlers/login.go
@@ -238,6 +238,14 @@ type VerifyPasswordRequestDto struct {
 // @Failure      400         {string} string "Bad Request"
 // @Failure      401         {string} string "Unauthorized or wrong step"
 // @Router       /logins/{loginToken}/verify-password [post]
+// MaxFailedPasswordAttempts is the per-loginToken cap on wrong-password
+// attempts before the loginToken is invalidated. RFC 6819 §5.1.4.2.3
+// recommends throttling/lockout against online password guessing on the
+// resource-owner credentials; without this cap a single anonymously-minted
+// loginToken supports unbounded brute force / spray within its 15-minute
+// TTL.
+const MaxFailedPasswordAttempts = 5
+
 func VerifyPassword(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	scope := middlewares.GetScope(ctx)
@@ -258,40 +266,60 @@ func VerifyPassword(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = updateLoginStep(ctx, loginToken, func(loginInfo *jsonTypes.LoginInfo) error {
-		dbContext := ioc.GetDependency[database.Context](scope)
+	tokenService := ioc.GetDependency[services.TokenService](scope)
+	dbContext := ioc.GetDependency[database.Context](scope)
 
-		if loginInfo.Step != jsonTypes.LoginStepPasswordVerification {
-			return utils.ErrHttpUnauthorized
-		}
+	rawLoginInfo, err := tokenService.GetToken(ctx, services.LoginSessionTokenType, loginToken)
+	if err != nil {
+		utils.HandleHttpError(w, fmt.Errorf("getting token: %w", err))
+		return
+	}
 
-		userFilter := repositories.NewUserFilter().VirtualServerId(loginInfo.VirtualServerId).Username(dto.Username)
-		user, err := dbContext.Users().FirstOrNil(ctx, userFilter)
-		if err != nil {
-			return err
-		}
-		if user == nil {
-			return utils.ErrHttpUnauthorized
-		}
+	var loginInfo jsonTypes.LoginInfo
+	if err := json.Unmarshal([]byte(rawLoginInfo), &loginInfo); err != nil {
+		utils.HandleHttpError(w, fmt.Errorf("unmarshal login info: %w", err))
+		return
+	}
 
-		credentialFilter := repositories.NewCredentialFilter().
-			UserId(user.Id()).
-			Type(repositories.CredentialTypePassword)
-		credential, err := dbContext.Credentials().FirstOrNil(ctx, credentialFilter)
-		if err != nil {
-			return utils.ErrHttpUnauthorized
-		}
+	if loginInfo.Step != jsonTypes.LoginStepPasswordVerification {
+		utils.HandleHttpError(w, utils.ErrHttpUnauthorized)
+		return
+	}
 
-		passwordDetails, err := credential.PasswordDetails()
-		if err != nil {
-			return utils.ErrHttpUnauthorized
-		}
+	user, ok, err := verifyPasswordCredential(ctx, dbContext, loginInfo.VirtualServerId, dto.Username, dto.Password)
+	if err != nil {
+		utils.HandleHttpError(w, fmt.Errorf("verifying password: %w", err))
+		return
+	}
 
-		if !utils.CompareHash(dto.Password, passwordDetails.HashedPassword) {
-			return utils.ErrHttpUnauthorized
+	if !ok {
+		loginInfo.FailedPasswordAttempts++
+		if loginInfo.FailedPasswordAttempts >= MaxFailedPasswordAttempts {
+			// Drop the loginToken entirely so the attacker cannot keep
+			// hammering the same anonymously-minted token; the user must
+			// restart the flow at /authorize.
+			if delErr := tokenService.DeleteToken(ctx, services.LoginSessionTokenType, loginToken); delErr != nil {
+				utils.HandleHttpError(w, fmt.Errorf("deleting login token: %w", delErr))
+				return
+			}
+		} else {
+			updated, marshalErr := json.Marshal(loginInfo)
+			if marshalErr != nil {
+				utils.HandleHttpError(w, fmt.Errorf("marshal login info: %w", marshalErr))
+				return
+			}
+			if updErr := tokenService.UpdateToken(ctx, services.LoginSessionTokenType, loginToken, string(updated), 15*time.Minute); updErr != nil {
+				utils.HandleHttpError(w, fmt.Errorf("update login token: %w", updErr))
+				return
+			}
 		}
+		utils.HandleHttpError(w, utils.ErrHttpUnauthorized)
+		return
+	}
 
-		loginInfo.UserId = user.Id()
+	err = updateLoginStep(ctx, loginToken, func(info *jsonTypes.LoginInfo) error {
+		info.UserId = user.Id()
+		info.FailedPasswordAttempts = 0
 		return nil
 	})
 	if err != nil {
@@ -300,6 +328,55 @@ func VerifyPassword(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// verifyPasswordCredential looks up the password credential for the given
+// (virtualServerId, username) pair and compares the supplied password
+// against the stored hash. It returns (user, true, nil) only when the user
+// exists, has a password credential, and the hash compares equal.
+//
+// On a wrong password / unknown user / missing credential it returns
+// (user-or-nil, false, nil) -- those are not errors, they're a failed
+// authentication attempt that the caller MUST count against the
+// loginToken's failed-attempt budget. A non-nil error is reserved for
+// underlying database failures.
+func verifyPasswordCredential(
+	ctx context.Context,
+	dbContext database.Context,
+	virtualServerId uuid.UUID,
+	username string,
+	password string,
+) (*repositories.User, bool, error) {
+	userFilter := repositories.NewUserFilter().VirtualServerId(virtualServerId).Username(username)
+	user, err := dbContext.Users().FirstOrNil(ctx, userFilter)
+	if err != nil {
+		return nil, false, fmt.Errorf("getting user: %w", err)
+	}
+	if user == nil {
+		return nil, false, nil
+	}
+
+	credentialFilter := repositories.NewCredentialFilter().
+		UserId(user.Id()).
+		Type(repositories.CredentialTypePassword)
+	credential, err := dbContext.Credentials().FirstOrNil(ctx, credentialFilter)
+	if err != nil {
+		return user, false, fmt.Errorf("getting credential: %w", err)
+	}
+	if credential == nil {
+		return user, false, nil
+	}
+
+	passwordDetails, err := credential.PasswordDetails()
+	if err != nil {
+		return user, false, nil
+	}
+
+	if !utils.CompareHash(password, passwordDetails.HashedPassword) {
+		return user, false, nil
+	}
+
+	return user, true, nil
 }
 
 // VerifyEmailToken advances the login after the user's email is verified.

--- a/internal/handlers/login_test.go
+++ b/internal/handlers/login_test.go
@@ -1,0 +1,113 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/The127/Keyline/internal/database"
+	"github.com/The127/Keyline/internal/mocks"
+	"github.com/The127/Keyline/internal/repositories"
+	repoMocks "github.com/The127/Keyline/internal/repositories/mocks"
+	"github.com/The127/Keyline/utils"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestMaxFailedPasswordAttempts_LowEnoughForOnlineGuessingMitigation(t *testing.T) {
+	t.Parallel()
+	// Sanity-check the threshold against RFC 6819 §5.1.4.2.3 guidance: a
+	// single anonymously-minted loginToken must not authorize a meaningful
+	// brute-force budget. Keep this assertion strict so a future bump is a
+	// deliberate, code-reviewed change.
+	assert.LessOrEqual(t, MaxFailedPasswordAttempts, 10)
+	assert.GreaterOrEqual(t, MaxFailedPasswordAttempts, 3)
+}
+
+func newPasswordVerifyTestContext(t *testing.T) (context.Context, *mocks.MockContext, *gomock.Controller) {
+	ctrl := gomock.NewController(t)
+	dbContext := mocks.NewMockContext(ctrl)
+	return context.Background(), dbContext, ctrl
+}
+
+func seedUserAndPasswordCredential(
+	t *testing.T,
+	dbContext *mocks.MockContext,
+	ctrl *gomock.Controller,
+	username string,
+	password string,
+) (*repositories.User, *repositories.Credential) {
+	t.Helper()
+	user := repositories.NewUser(username, "Display "+username, username+"@test", uuid.New())
+	user.Mock(time.Now())
+
+	userRepository := repoMocks.NewMockUserRepository(ctrl)
+	userRepository.EXPECT().FirstOrNil(gomock.Any(), gomock.Any()).Return(user, nil).AnyTimes()
+	dbContext.EXPECT().Users().Return(userRepository).AnyTimes()
+
+	credential := repositories.NewCredential(user.Id(), &repositories.CredentialPasswordDetails{
+		HashedPassword: utils.HashPassword(password),
+		Temporary:      false,
+	})
+	credentialRepository := repoMocks.NewMockCredentialRepository(ctrl)
+	credentialRepository.EXPECT().FirstOrNil(gomock.Any(), gomock.Any()).Return(credential, nil).AnyTimes()
+	dbContext.EXPECT().Credentials().Return(credentialRepository).AnyTimes()
+
+	return user, credential
+}
+
+func TestVerifyPasswordCredential_AcceptsCorrectPassword(t *testing.T) {
+	t.Parallel()
+	ctx, dbContext, ctrl := newPasswordVerifyTestContext(t)
+	defer ctrl.Finish()
+	expectedUser, _ := seedUserAndPasswordCredential(t, dbContext, ctrl, "alice", "correct-horse-battery-staple")
+
+	user, ok, err := verifyPasswordCredential(ctx, dbContext, uuid.New(), "alice", "correct-horse-battery-staple")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NotNil(t, user)
+	assert.Equal(t, expectedUser.Id(), user.Id())
+}
+
+func TestVerifyPasswordCredential_RejectsWrongPassword(t *testing.T) {
+	t.Parallel()
+	ctx, dbContext, ctrl := newPasswordVerifyTestContext(t)
+	defer ctrl.Finish()
+	seedUserAndPasswordCredential(t, dbContext, ctrl, "alice", "correct-horse-battery-staple")
+
+	user, ok, err := verifyPasswordCredential(ctx, dbContext, uuid.New(), "alice", "wrong-password")
+	require.NoError(t, err)
+	require.False(t, ok)
+	// User is still returned on a wrong-password to allow callers to log
+	// the attempt against the user; the bool result is what gates auth.
+	assert.NotNil(t, user)
+}
+
+func TestVerifyPasswordCredential_RejectsUnknownUser(t *testing.T) {
+	t.Parallel()
+	ctx, dbContext, ctrl := newUnknownUserContext(t)
+	defer ctrl.Finish()
+
+	user, ok, err := verifyPasswordCredential(ctx, dbContext, uuid.New(), "ghost", "anything")
+	require.NoError(t, err)
+	require.False(t, ok)
+	assert.Nil(t, user)
+}
+
+func newUnknownUserContext(t *testing.T) (context.Context, *mocks.MockContext, *gomock.Controller) {
+	ctrl := gomock.NewController(t)
+	dbContext := mocks.NewMockContext(ctrl)
+	userRepository := repoMocks.NewMockUserRepository(ctrl)
+	userRepository.EXPECT().FirstOrNil(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	dbContext.EXPECT().Users().Return(userRepository).AnyTimes()
+	return context.Background(), dbContext, ctrl
+}
+
+// Compile-time check: verifyPasswordCredential's first parameter must be a
+// database.Context, not the concrete mock; if this assignment fails to
+// compile a refactor changed the helper's signature in a way the
+// VerifyPassword caller can no longer satisfy.
+var _ func(context.Context, database.Context, uuid.UUID, string, string) (*repositories.User, bool, error) = verifyPasswordCredential

--- a/internal/handlers/login_test.go
+++ b/internal/handlers/login_test.go
@@ -39,7 +39,7 @@ func seedUserAndPasswordCredential(
 	ctrl *gomock.Controller,
 	username string,
 	password string,
-) (*repositories.User, *repositories.Credential) {
+) *repositories.User {
 	t.Helper()
 	user := repositories.NewUser(username, "Display "+username, username+"@test", uuid.New())
 	user.Mock(time.Now())
@@ -56,14 +56,14 @@ func seedUserAndPasswordCredential(
 	credentialRepository.EXPECT().FirstOrNil(gomock.Any(), gomock.Any()).Return(credential, nil).AnyTimes()
 	dbContext.EXPECT().Credentials().Return(credentialRepository).AnyTimes()
 
-	return user, credential
+	return user
 }
 
 func TestVerifyPasswordCredential_AcceptsCorrectPassword(t *testing.T) {
 	t.Parallel()
 	ctx, dbContext, ctrl := newPasswordVerifyTestContext(t)
 	defer ctrl.Finish()
-	expectedUser, _ := seedUserAndPasswordCredential(t, dbContext, ctrl, "alice", "correct-horse-battery-staple")
+	expectedUser := seedUserAndPasswordCredential(t, dbContext, ctrl, "alice", "correct-horse-battery-staple")
 
 	user, ok, err := verifyPasswordCredential(ctx, dbContext, uuid.New(), "alice", "correct-horse-battery-staple")
 	require.NoError(t, err)

--- a/internal/jsonTypes/LoginInfo.go
+++ b/internal/jsonTypes/LoginInfo.go
@@ -29,6 +29,7 @@ type LoginInfo struct {
 	OriginalUrl              string    `json:"originalUrl"`
 	TotpSecret               string    `json:"totpSecret"`
 	DeviceCode               string    `json:"deviceCode"`
+	FailedPasswordAttempts   int       `json:"failedPasswordAttempts"`
 }
 
 func NewLoginInfo(virtualServer *repositories.VirtualServer, application *repositories.Application, originalUrl string) LoginInfo {

--- a/tests/e2e/loginbruteforce_test.go
+++ b/tests/e2e/loginbruteforce_test.go
@@ -1,0 +1,262 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/The127/Keyline/config"
+	"github.com/The127/Keyline/internal/authentication"
+	"github.com/The127/Keyline/internal/commands"
+	"github.com/The127/Keyline/internal/database"
+	"github.com/The127/Keyline/internal/handlers"
+	"github.com/The127/Keyline/internal/middlewares"
+	"github.com/The127/Keyline/internal/repositories"
+	"github.com/The127/Keyline/utils"
+
+	"github.com/The127/ioc"
+	"github.com/The127/mediatr"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	loginBfAppName       = "test-login-bf-app"
+	loginBfUserUsername  = "test-login-bf-user"
+	loginBfUserPassword  = "correct-horse-battery-staple"
+	loginBfOtherUsername = "test-login-bf-other"
+	loginBfOtherPassword = "another-correct-password"
+)
+
+func init() {
+	for _, backend := range testBackends {
+		backend := backend
+		Describe("Login brute-force protection ["+backend.name+"]", Ordered, func() {
+			var h *harness
+
+			BeforeAll(func() {
+				if backend.dbMode == config.DatabaseModePostgres && !postgresBackendAvailable() {
+					Skip("Postgres not available")
+				}
+				h = newE2eTestHarness(backend.dbMode, nil)
+				err := setupLoginBruteForceFixtures(h.Scope())
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			AfterAll(func() {
+				if h != nil {
+					h.Close()
+				}
+			})
+
+			// Each spec mints its own fresh loginToken so they don't share
+			// failed-attempt counters.
+			mintLoginToken := func() string {
+				deviceResp, err := h.Client().Oidc().BeginDeviceFlow(h.Ctx(), loginBfAppName, "openid")
+				Expect(err).ToNot(HaveOccurred())
+				loginToken, err := h.Client().Oidc().PostActivate(h.Ctx(), deviceResp.UserCode)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(loginToken).ToNot(BeEmpty())
+				return loginToken
+			}
+
+			Describe("POST /logins/{loginToken}/verify-password", func() {
+				It("accepts the correct password on the first attempt", func() {
+					loginToken := mintLoginToken()
+					err := h.Client().Oidc().VerifyPassword(h.Ctx(), loginToken, loginBfUserUsername, loginBfUserPassword)
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("accepts the correct password before the threshold is reached", func() {
+					loginToken := mintLoginToken()
+					// MaxFailedPasswordAttempts - 1 wrong attempts must not
+					// invalidate the loginToken: the user gets the threshold
+					// minus one chances before lockout.
+					for i := 0; i < handlers.MaxFailedPasswordAttempts-1; i++ {
+						err := h.Client().Oidc().VerifyPassword(h.Ctx(), loginToken, loginBfUserUsername, fmt.Sprintf("wrong-%d", i))
+						Expect(err).To(HaveOccurred())
+					}
+					err := h.Client().Oidc().VerifyPassword(h.Ctx(), loginToken, loginBfUserUsername, loginBfUserPassword)
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("invalidates the loginToken after MaxFailedPasswordAttempts wrong passwords", func() {
+					loginToken := mintLoginToken()
+					for i := 0; i < handlers.MaxFailedPasswordAttempts; i++ {
+						err := h.Client().Oidc().VerifyPassword(h.Ctx(), loginToken, loginBfUserUsername, fmt.Sprintf("wrong-%d", i))
+						Expect(err).To(HaveOccurred())
+					}
+					// Even the CORRECT password is rejected now: the
+					// loginToken has been deleted from the token store.
+					err := h.Client().Oidc().VerifyPassword(h.Ctx(), loginToken, loginBfUserUsername, loginBfUserPassword)
+					Expect(err).To(HaveOccurred())
+				})
+
+				It("counts failed attempts across different usernames on the same loginToken (spray)", func() {
+					loginToken := mintLoginToken()
+					// Spray ONE password across MaxFailedPasswordAttempts
+					// distinct usernames. The counter MUST tick per attempt
+					// regardless of the username supplied -- otherwise an
+					// attacker rotating usernames would never trip the cap.
+					for i := 0; i < handlers.MaxFailedPasswordAttempts; i++ {
+						err := h.Client().Oidc().VerifyPassword(h.Ctx(), loginToken, fmt.Sprintf("victim-%d", i), "spray")
+						Expect(err).To(HaveOccurred())
+					}
+					err := h.Client().Oidc().VerifyPassword(h.Ctx(), loginToken, loginBfUserUsername, loginBfUserPassword)
+					Expect(err).To(HaveOccurred())
+				})
+
+				It("counts failed attempts against unknown users (lockout still triggers)", func() {
+					loginToken := mintLoginToken()
+					// Ghost users must also tick the counter -- otherwise
+					// an attacker could bypass the cap by sending bogus
+					// usernames between real attempts.
+					for i := 0; i < handlers.MaxFailedPasswordAttempts; i++ {
+						err := h.Client().Oidc().VerifyPassword(h.Ctx(), loginToken, fmt.Sprintf("ghost-%d", i), "anything")
+						Expect(err).To(HaveOccurred())
+					}
+					err := h.Client().Oidc().VerifyPassword(h.Ctx(), loginToken, loginBfUserUsername, loginBfUserPassword)
+					Expect(err).To(HaveOccurred())
+				})
+
+				It("resets the counter on a successful login (separate loginToken)", func() {
+					// A successful login completes the flow and burns the
+					// loginToken via FinishLogin; subsequent attempts on
+					// that token are 401, so this case is mostly a sanity
+					// check that a fresh loginToken starts clean and the
+					// fix doesn't leak counter state across loginTokens.
+					tokenA := mintLoginToken()
+					for i := 0; i < handlers.MaxFailedPasswordAttempts-1; i++ {
+						err := h.Client().Oidc().VerifyPassword(h.Ctx(), tokenA, loginBfUserUsername, "wrong")
+						Expect(err).To(HaveOccurred())
+					}
+					tokenB := mintLoginToken()
+					// Token B must accept MaxFailedPasswordAttempts-1 wrong
+					// attempts of its own -- the counter is per-loginToken.
+					for i := 0; i < handlers.MaxFailedPasswordAttempts-1; i++ {
+						err := h.Client().Oidc().VerifyPassword(h.Ctx(), tokenB, loginBfUserUsername, "wrong")
+						Expect(err).To(HaveOccurred())
+					}
+					err := h.Client().Oidc().VerifyPassword(h.Ctx(), tokenB, loginBfUserUsername, loginBfUserPassword)
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("supports a fresh loginToken after the previous one was burned", func() {
+					tokenA := mintLoginToken()
+					for i := 0; i < handlers.MaxFailedPasswordAttempts; i++ {
+						_ = h.Client().Oidc().VerifyPassword(h.Ctx(), tokenA, loginBfUserUsername, "wrong")
+					}
+					// Burned tokenA -- correct password rejected.
+					err := h.Client().Oidc().VerifyPassword(h.Ctx(), tokenA, loginBfUserUsername, loginBfUserPassword)
+					Expect(err).To(HaveOccurred())
+
+					// A second, anonymously-minted loginToken still works.
+					// The fix MUST NOT lock the user out at the credential
+					// level -- the cap is per-loginToken only.
+					tokenB := mintLoginToken()
+					err = h.Client().Oidc().VerifyPassword(h.Ctx(), tokenB, loginBfUserUsername, loginBfUserPassword)
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+	}
+}
+
+func setupLoginBruteForceFixtures(scope *ioc.DependencyProvider) error {
+	subscope := scope.NewScope()
+	defer subscope.Close()
+
+	ctx := context.Background()
+	ctx = middlewares.ContextWithScope(ctx, subscope)
+	ctx = authentication.ContextWithCurrentUser(ctx, authentication.SystemUser())
+
+	m := ioc.GetDependency[mediatr.Mediator](subscope)
+	dbContext := ioc.GetDependency[database.Context](subscope)
+
+	_, err := mediatr.Send[*commands.CreateProjectResponse](ctx, m, commands.CreateProject{
+		VirtualServerName: "test-vs",
+		Slug:              "login-bf-project",
+		Name:              "Login Brute-force Project",
+	})
+	if err != nil {
+		return fmt.Errorf("creating project: %w", err)
+	}
+	if err := dbContext.SaveChanges(ctx); err != nil {
+		return fmt.Errorf("saving project: %w", err)
+	}
+
+	appResp, err := mediatr.Send[*commands.CreateApplicationResponse](ctx, m, commands.CreateApplication{
+		VirtualServerName:      "test-vs",
+		ProjectSlug:            "login-bf-project",
+		Name:                   loginBfAppName,
+		DisplayName:            "Test Login Brute-force App",
+		Type:                   repositories.ApplicationTypePublic,
+		RedirectUris:           []string{"http://localhost:9999/callback"},
+		PostLogoutRedirectUris: []string{},
+	})
+	if err != nil {
+		return fmt.Errorf("creating application: %w", err)
+	}
+	if err := dbContext.SaveChanges(ctx); err != nil {
+		return fmt.Errorf("saving application: %w", err)
+	}
+
+	_, err = mediatr.Send[*commands.PatchApplicationResponse](ctx, m, commands.PatchApplication{
+		VirtualServerName: "test-vs",
+		ProjectSlug:       "login-bf-project",
+		ApplicationId:     appResp.Id,
+		DeviceFlowEnabled: utils.Ptr(true),
+	})
+	if err != nil {
+		return fmt.Errorf("enabling device flow: %w", err)
+	}
+	if err := dbContext.SaveChanges(ctx); err != nil {
+		return fmt.Errorf("saving device flow flag: %w", err)
+	}
+
+	if err := seedUserWithPassword(ctx, m, dbContext, loginBfUserUsername, loginBfUserPassword); err != nil {
+		return err
+	}
+	if err := seedUserWithPassword(ctx, m, dbContext, loginBfOtherUsername, loginBfOtherPassword); err != nil {
+		return err
+	}
+	return nil
+}
+
+func seedUserWithPassword(
+	ctx context.Context,
+	m mediatr.Mediator,
+	dbContext database.Context,
+	username string,
+	password string,
+) error {
+	userResp, err := mediatr.Send[*commands.CreateUserResponse](ctx, m, commands.CreateUser{
+		VirtualServerName: "test-vs",
+		DisplayName:       "Display " + username,
+		Username:          username,
+		Email:             username + "@test.local",
+		EmailVerified:     true,
+	})
+	if err != nil {
+		return fmt.Errorf("creating user %s: %w", username, err)
+	}
+	if err := dbContext.SaveChanges(ctx); err != nil {
+		return fmt.Errorf("saving user %s: %w", username, err)
+	}
+
+	cred := repositories.NewCredential(userResp.Id, &repositories.CredentialPasswordDetails{
+		HashedPassword: utils.HashPassword(password),
+		Temporary:      false,
+	})
+	dbContext.Credentials().Insert(cred)
+	if err := dbContext.SaveChanges(ctx); err != nil {
+		return fmt.Errorf("saving credential for %s: %w", username, err)
+	}
+	return nil
+}
+
+// Compile-time guard: setupLoginBruteForceFixtures must remain compatible
+// with newE2eTestHarness's scope shape. Catches refactors of the harness.
+var _ = uuid.Nil


### PR DESCRIPTION
## Summary

- `POST /logins/{loginToken}/verify-password` accepted unbounded password attempts on one anonymously-minted loginToken in its 15-min TTL.
- `username` was read from the body, so the same loginToken supported password spray across many users — no per-loginToken counter, no per-user lockout, no per-IP throttle.
- Adds a `FailedPasswordAttempts` counter to `LoginInfo` and deletes the loginToken once it hits `MaxFailedPasswordAttempts = 5`. RFC 6819 §5.1.4.2.3 (online password guessing) was the relevant guidance.

## What changed

- `internal/jsonTypes/LoginInfo.go` — add `FailedPasswordAttempts int \`json:"failedPasswordAttempts"\`` to `LoginInfo`. Persisted as JSON in Redis alongside the existing fields; no migration.
- `internal/handlers/login.go` — extract `verifyPasswordCredential` as a pure helper returning `(user, ok, err)`; rewrite `VerifyPassword` to bypass `updateLoginStep` on the wrong-password path so the counter increment can be persisted (`UpdateToken`) or the loginToken deleted (`DeleteToken`) once the cap is reached. On success, delegate to `updateLoginStep` to advance the step and reset the counter.
- `internal/handlers/login_test.go` — unit tests for the extracted helper and a sanity-check test on the threshold constant.
- `tests/e2e/loginbruteforce_test.go` — Ginkgo e2e regression suite (build tag `e2e`), 7 specs × 2 backends = 14 specs.

The counter is exported (`handlers.MaxFailedPasswordAttempts`) so the e2e tests reference it directly — bumping the constant correspondingly bumps the e2e expectations, no divergence.

## Compatibility notes

- HTTP shape unchanged for callers: wrong-password is still `401`, expired-token (deleted loginToken) returns `401` on subsequent `verify-password` and `404` on `GET /logins/<token>` (the existing `GetLoginState` already handles missing-token as expired session).
- No new error codes, no schema migration, no API change in the OpenAPI spec.
- The cap is per-loginToken only — the user can restart at `/authorize` after a burned token. There is no per-credential lockout in this PR; that's a follow-up (schema migration, "locked_until" UI surface, password-reset interaction — distinct bug class).
- The existing UI flow that lets a user retry with a *different* username on the same loginToken (typed wrong username, sees error, retries with right one) is preserved — every attempt eats from the same 5-attempt budget regardless of which username was supplied.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/handlers/` — unit tests including the new
  `TestVerifyPasswordCredential_*` and `TestMaxFailedPasswordAttempts_*` specs.
- [x] `go test -tags=e2e ./tests/e2e/` — 14 of 14 new specs pass on both Postgres and memory backends; full e2e suite remains green (~13s, no regressions).
- [x] PoC in `security_issues/login-brute-force-no-rate-limit/` exits 0 in both pre-fix (BUG CONFIRMED) and post-fix (blocked, legitimate flow still works) states.

## Out of scope (related, not fixed here)

- Per-credential lockout (`failed_attempts` / `locked_until` on the `credentials` row). Stronger because it survives the attacker minting a fresh loginToken, but a much larger change.
- Per-IP / per-account-name rate limiting at the loginRouter middleware layer. Defense-in-depth.
- Binding `username` to the loginToken on first attempt. Closes spray cleanly but breaks UI retry-with-different-username; deferred.
- Audit-log entry on failed `verify-password` attempts. Today the only signal is the HTTP access log.