### PR TITLE
fix(login): validate clientData.Origin against the frontend origin

### DIFF
--- a/internal/handlers/login.go
+++ b/internal/handlers/login.go
@@ -27,6 +27,7 @@ import (
 	"github.com/The127/Keyline/templates"
 	"github.com/The127/Keyline/utils"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/The127/go-clock"
@@ -939,6 +940,22 @@ func FinishPasskeyLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// WebAuthn L3 §7.2 step 9: the RP MUST verify that clientData.Origin
+	// is an origin it expects. The login UI runs at config.Frontend.ExternalUrl,
+	// so a real browser will set Origin to that URL's scheme+host(+port).
+	// Skipping this check lets a non-browser caller (which never had a
+	// browser-side rpId binding to begin with) submit an assertion with
+	// any Origin string at all.
+	expectedOrigin, err := webauthnExpectedOrigin(config.C.Frontend.ExternalUrl)
+	if err != nil {
+		utils.HandleHttpError(w, fmt.Errorf("computing expected webauthn origin: %w", err))
+		return
+	}
+	if clientData.Origin != expectedOrigin {
+		utils.HandleHttpError(w, fmt.Errorf("clientData origin %q does not match expected origin: %w", clientData.Origin, utils.ErrHttpUnauthorized))
+		return
+	}
+
 	challengeFromClient, err := base64.RawURLEncoding.DecodeString(clientData.Challenge)
 	if err != nil {
 		utils.HandleHttpError(w, err)
@@ -1087,4 +1104,27 @@ func validateSignature(pubKey any, pubKeyAlgorithm int, message, sigBytes []byte
 	}
 
 	return nil
+}
+
+// webauthnExpectedOrigin returns the origin (scheme + host[:port]) that
+// `clientData.Origin` MUST equal for a WebAuthn assertion accepted at
+// /logins/{token}/passkey/finish. The expected origin is derived from
+// config.Frontend.ExternalUrl: that's where the login UI runs, and a
+// real browser sets clientData.Origin to that URL's scheme+host+port
+// when JS on the login page calls navigator.credentials.get().
+//
+// Any path on Frontend.ExternalUrl is stripped — origins per RFC 6454
+// are scheme + host + port, never a path.
+func webauthnExpectedOrigin(frontendExternalUrl string) (string, error) {
+	if frontendExternalUrl == "" {
+		return "", fmt.Errorf("frontend.externalUrl is not configured")
+	}
+	u, err := url.Parse(frontendExternalUrl)
+	if err != nil {
+		return "", fmt.Errorf("parsing frontend.externalUrl: %w", err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("frontend.externalUrl is missing scheme or host: %q", frontendExternalUrl)
+	}
+	return u.Scheme + "://" + u.Host, nil
 }

--- a/internal/handlers/login_test.go
+++ b/internal/handlers/login_test.go
@@ -27,6 +27,64 @@ func TestMaxFailedPasswordAttempts_LowEnoughForOnlineGuessingMitigation(t *testi
 	assert.GreaterOrEqual(t, MaxFailedPasswordAttempts, 3)
 }
 
+func TestWebauthnExpectedOrigin(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name         string
+		frontendUrl  string
+		want         string
+		wantErr      bool
+	}{
+		{
+			name:        "bare http origin",
+			frontendUrl: "http://localhost:5173",
+			want:        "http://localhost:5173",
+		},
+		{
+			name:        "https without explicit port",
+			frontendUrl: "https://app.keyline-oidc.com",
+			want:        "https://app.keyline-oidc.com",
+		},
+		{
+			// Frontend.ExternalUrl might have a trailing path in some
+			// dev configs; clientData.Origin per RFC 6454 is just
+			// scheme+host(+port), so the helper strips paths.
+			name:        "trailing path is stripped",
+			frontendUrl: "https://app.keyline-oidc.com/keyline",
+			want:        "https://app.keyline-oidc.com",
+		},
+		{
+			name:        "explicit non-default port preserved",
+			frontendUrl: "https://login.example:8443",
+			want:        "https://login.example:8443",
+		},
+		{
+			name:        "empty config rejected",
+			frontendUrl: "",
+			wantErr:     true,
+		},
+		{
+			name:        "scheme-less url rejected",
+			frontendUrl: "app.keyline-oidc.com",
+			wantErr:     true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := webauthnExpectedOrigin(tc.frontendUrl)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
 func newPasswordVerifyTestContext(t *testing.T) (context.Context, *mocks.MockContext, *gomock.Controller) {
 	ctrl := gomock.NewController(t)
 	dbContext := mocks.NewMockContext(ctrl)

--- a/tests/e2e/passkeycrosstenant_test.go
+++ b/tests/e2e/passkeycrosstenant_test.go
@@ -38,6 +38,11 @@ const (
 	passkeyTargetURI     = "http://localhost:9100/passkey-callback"
 	passkeyPkceVerifier  = "passkey-cross-tenant-verifier-padding-padding-12"
 	cosePublicKeyEd25519 = -8
+	// passkeyFrontendOrigin is what the WebAuthn ceremony's clientData.Origin
+	// must equal post PR #284. The harness sets config.C.Frontend.ExternalUrl
+	// to this in BeforeAll so the helper that derives the expected origin
+	// in handlers/login.go produces the same string.
+	passkeyFrontendOrigin = "http://localhost:5173"
 )
 
 // passkeyTestKey holds an ed25519 keypair plus the credential id we wire
@@ -63,6 +68,11 @@ func init() {
 					Skip("Postgres not available")
 				}
 				h = newE2eTestHarness(backend.dbMode, nil)
+				// FinishPasskeyLogin derives the expected clientData.Origin
+				// from config.C.Frontend.ExternalUrl. The harness leaves the
+				// field zero, so set it explicitly here -- otherwise every
+				// /passkey/finish call below would fail the origin check.
+				config.C.Frontend.ExternalUrl = passkeyFrontendOrigin
 				var err error
 				attackerKey, targetUserKey, err = setupPasskeyCrossTenantFixtures(h)
 				Expect(err).ToNot(HaveOccurred())
@@ -107,9 +117,10 @@ func init() {
 			}
 
 			// passkeyFinish drives /passkey/start, signs the challenge with
-			// `key`, and POSTs to /passkey/finish. Returns the response so
-			// callers can assert on status / body.
-			passkeyFinish := func(loginToken string, key *passkeyTestKey) *http.Response {
+			// `key`, and POSTs to /passkey/finish using `origin` as
+			// clientData.Origin. Returns the response so callers can
+			// assert on status / body.
+			passkeyFinish := func(loginToken string, key *passkeyTestKey, origin string) *http.Response {
 				startResp, err := http.Post(
 					fmt.Sprintf("%s/logins/%s/passkey/start", h.ApiUrl(), loginToken),
 					"", nil,
@@ -130,7 +141,7 @@ func init() {
 				clientData := map[string]string{
 					"type":      "webauthn.get",
 					"challenge": base64.RawURLEncoding.EncodeToString(challengeBytes),
-					"origin":    "https://test.invalid",
+					"origin":    origin,
 				}
 				clientDataBytes, err := json.Marshal(clientData)
 				Expect(err).ToNot(HaveOccurred())
@@ -170,7 +181,7 @@ func init() {
 			Describe("POST /logins/{loginToken}/passkey/finish", func() {
 				It("accepts a webauthn credential whose owner is in the same VS as the loginToken (happy path)", func() {
 					loginToken := mintLoginToken(h.VirtualServer())
-					resp := passkeyFinish(loginToken, targetUserKey)
+					resp := passkeyFinish(loginToken, targetUserKey, passkeyFrontendOrigin)
 					defer resp.Body.Close()
 					Expect(resp.StatusCode).To(Equal(http.StatusNoContent),
 						"same-VS passkey login must succeed")
@@ -186,7 +197,7 @@ func init() {
 					// credential.UserId() against loginInfo.VirtualServerId
 					// and rejects with Unauthorized.
 					loginToken := mintLoginToken(h.VirtualServer())
-					resp := passkeyFinish(loginToken, attackerKey)
+					resp := passkeyFinish(loginToken, attackerKey, passkeyFrontendOrigin)
 					defer resp.Body.Close()
 					Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized),
 						"cross-VS passkey login must be rejected")
@@ -199,7 +210,7 @@ func init() {
 						publicKey:    attackerKey.publicKey,
 						privateKey:   attackerKey.privateKey,
 					}
-					resp := passkeyFinish(loginToken, bogus)
+					resp := passkeyFinish(loginToken, bogus, passkeyFrontendOrigin)
 					defer resp.Body.Close()
 					Expect(resp.StatusCode).ToNot(Equal(http.StatusNoContent),
 						"unknown credential id must not authenticate")
@@ -212,10 +223,25 @@ func init() {
 					// guards against an over-broad fix that would also
 					// block the legitimate same-VS case.
 					loginToken := mintLoginToken(passkeyAttackerVS)
-					resp := passkeyFinish(loginToken, attackerKey)
+					resp := passkeyFinish(loginToken, attackerKey, passkeyFrontendOrigin)
 					defer resp.Body.Close()
 					Expect(resp.StatusCode).To(Equal(http.StatusNoContent),
 						"attacker's credential must still authenticate the attacker in their own VS")
+				})
+
+				It("rejects a clientData.Origin that does not match the configured frontend origin (REGRESSION: WebAuthn L3 §7.2 step 9)", func() {
+					// Pre-fix the Origin field was parsed but never
+					// compared. A non-browser caller (or a malicious page
+					// that somehow bypassed the browser's rpId check)
+					// could submit a syntactically-valid assertion with
+					// any Origin string. Post-fix the handler compares
+					// against config.C.Frontend.ExternalUrl and rejects
+					// any other origin with Unauthorized.
+					loginToken := mintLoginToken(h.VirtualServer())
+					resp := passkeyFinish(loginToken, targetUserKey, "https://attacker.invalid")
+					defer resp.Body.Close()
+					Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized),
+						"wrong-origin passkey assertion must be rejected")
 				})
 			})
 		})


### PR DESCRIPTION
## Summary

- `FinishPasskeyLogin` parsed `clientData.Origin` into a struct field and never compared it. WebAuthn L3 §7.2 step 9 requires the relying party to verify the origin.
- Practical window is narrow (browsers enforce rpId binding, and PR #283 closed the most impactful cross-VS misuse), but skipping the check lets non-browser callers submit assertions with any Origin string and is the second-line defense against future cross-domain credential-lookup regressions.
- Fix: derive the expected origin from `config.Frontend.ExternalUrl` (scheme + host[:port], path stripped per RFC 6454), compare to `clientData.Origin`, reject mismatch with `Unauthorized`.

## What changed

- `internal/handlers/login.go` — new `webauthnExpectedOrigin` helper; `FinishPasskeyLogin` calls it after the `clientData.Type` check, mirroring WebAuthn L3 §7.2 steps 7-9 order (type, origin, challenge).
- `internal/handlers/login_test.go` — `TestWebauthnExpectedOrigin` table-driven unit test (no harness): bare http/https origin, trailing path stripping, explicit-port preservation, empty config rejection, scheme-less URL rejection.
- `tests/e2e/passkeycrosstenant_test.go` — new spec "rejects a `clientData.Origin` that does not match the configured frontend origin"; existing four specs updated to send the correct origin; the suite's `BeforeAll` now sets `config.C.Frontend.ExternalUrl` since the e2e harness leaves the field zero by default.

## Compatibility notes

- Any deployment that does not set `frontend.externalUrl` in production will now hit the panic in `setFrontendDefaultsOrPanic` exactly as before — that path is unchanged. Dev defaults to `http://localhost:5173`, matching what a real browser sends.
- WebAuthn ceremonies driven from a non-frontend origin (custom CLI, extension, alternate UI) will now fail unless they spoof `clientData.Origin` to match the configured frontend URL. That is the intended behavior; if a real second origin needs to be supported, a future PR can move from a single-string compare to an allow-list.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/handlers/` (passes incl. new `TestWebauthnExpectedOrigin`)
- [x] `go test -tags=e2e ./tests/e2e/` (10 passkey specs across postgres + memory; full suite green)
- [x] `go test -tags=integration ./tests/integration/`
- [x] `golangci-lint run` (no issues)
- [x] PoC at `security_issues/passkey-no-origin-check/` exits 0 with `EXPECT_FIX=1` (EXPLOIT blocked, legit flow works) and exits 0 against `origin/main` with `EXPECT_FIX=0` (bug present).

## Out of scope

- Registration-side origin validation in `PasskeyValidateCreateChallengeResponse` (and the bigger registration-side issue that the kvStore challenge is fetched but `Get` is never called, accepting any `dto.Id`). Worth a separate PR.
- Per-credential origin binding (storing the origin at registration and comparing per-credential at login). Not useful until Keyline supports multiple frontend origins, which it does not today.