### PR TITLE
fix(roles): guard PatchRole and DeleteRole on the system project

### DIFF
--- a/internal/commands/DeleteRole.go
+++ b/internal/commands/DeleteRole.go
@@ -3,11 +3,13 @@ package commands
 import (
 	"context"
 	"fmt"
+	"github.com/The127/Keyline/internal/authentication"
 	"github.com/The127/Keyline/internal/authentication/permissions"
 	"github.com/The127/Keyline/internal/behaviours"
 	"github.com/The127/Keyline/internal/database"
 	"github.com/The127/Keyline/internal/middlewares"
 	"github.com/The127/Keyline/internal/repositories"
+	"github.com/The127/Keyline/utils"
 
 	"github.com/The127/ioc"
 
@@ -54,6 +56,18 @@ func HandleDeleteRole(ctx context.Context, command DeleteRole) (*DeleteRoleRespo
 	project, err := dbContext.Projects().FirstOrErr(ctx, projectFilter)
 	if err != nil {
 		return nil, fmt.Errorf("getting project: %w", err)
+	}
+
+	// Mirror of CreateRole's system-project gate. Deleting the system-
+	// project `admin` or `system-admin` role would either brick the VS
+	// or strip a SaaS operator of permissions; either way it's a
+	// privileged operation that must require the same SystemUser perm
+	// CreateRole demands for inserts.
+	if project.SystemProject() {
+		currentUser := authentication.GetCurrentUser(ctx)
+		if !currentUser.HasPermission(permissions.SystemUser).IsSuccess() {
+			return nil, fmt.Errorf("deleting roles in system project requires system user permission: %w", utils.ErrHttpUnauthorized)
+		}
 	}
 
 	roleFilter := repositories.NewRoleFilter().

--- a/internal/commands/DeleteRole_test.go
+++ b/internal/commands/DeleteRole_test.go
@@ -20,16 +20,16 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-type PatchRoleCommandSuite struct {
+type DeleteRoleCommandSuite struct {
 	suite.Suite
 }
 
-func TestPatchRoleCommandSuite(t *testing.T) {
+func TestDeleteRoleCommandSuite(t *testing.T) {
 	t.Parallel()
-	suite.Run(t, new(PatchRoleCommandSuite))
+	suite.Run(t, new(DeleteRoleCommandSuite))
 }
 
-func (s *PatchRoleCommandSuite) createContext(
+func (s *DeleteRoleCommandSuite) createContext(
 	ctrl *gomock.Controller,
 	virtualServerRepository repositories.VirtualServerRepository,
 	projectRepository repositories.ProjectRepository,
@@ -62,82 +62,26 @@ func (s *PatchRoleCommandSuite) createContext(
 	return middlewares.ContextWithScope(s.T().Context(), scope)
 }
 
-func (s *PatchRoleCommandSuite) TestHappyPath() {
+func (s *DeleteRoleCommandSuite) TestVirtualServerError() {
 	// arrange
 	ctrl := gomock.NewController(s.T())
 	defer ctrl.Finish()
 
-	now := time.Now()
-
-	virtualServer := repositories.NewVirtualServer("virtualServer", "Virtual Server")
-	virtualServer.Mock(now)
 	virtualServerRepository := mocks.NewMockVirtualServerRepository(ctrl)
-	virtualServerRepository.EXPECT().FirstOrErr(gomock.Any(), gomock.Cond(func(x *repositories.VirtualServerFilter) bool {
-		return x.GetName() == "virtualServer"
-	})).Return(virtualServer, nil)
+	virtualServerRepository.EXPECT().FirstOrErr(gomock.Any(), gomock.Any()).Return(nil, errors.New("error"))
 
-	project := repositories.NewProject(virtualServer.Id(), "project", "Project", "Test Project")
-	project.Mock(now)
-	projectRepository := mocks.NewMockProjectRepository(ctrl)
-	projectRepository.EXPECT().FirstOrErr(gomock.Any(), gomock.Cond(func(x *repositories.ProjectFilter) bool {
-		return x.GetSlug() == "project"
-	})).Return(project, nil)
-
-	role := repositories.NewRole(virtualServer.Id(), project.Id(), "role", "description")
-	role.Mock(now)
-	roleRepository := mocks.NewMockRoleRepository(ctrl)
-	roleRepository.EXPECT().FirstOrErr(gomock.Any(), gomock.Cond(func(x *repositories.RoleFilter) bool {
-		return x.GetId() == role.Id()
-	})).Return(role, nil)
-	roleRepository.EXPECT().Update(gomock.Cond(func(x *repositories.Role) bool {
-		return x.Name() == "new name" && x.Description() == "new description"
-	}))
-
-	ctx := s.createContext(ctrl, virtualServerRepository, projectRepository, roleRepository)
-	cmd := PatchRole{
-		VirtualServerName: virtualServer.Name(),
-		ProjectSlug:       project.Slug(),
-		RoleId:            role.Id(),
-		Name:              utils.Ptr("new name"),
-		Description:       utils.Ptr("new description"),
-	}
+	ctx := s.createContext(ctrl, virtualServerRepository, nil, nil)
+	cmd := DeleteRole{}
 
 	// act
-	resp, err := HandlePatchRole(ctx, cmd)
-
-	// assert
-	s.Require().NoError(err)
-	s.NotNil(resp)
-}
-
-func (s *PatchRoleCommandSuite) TestRoleError() {
-	// arrange
-	ctrl := gomock.NewController(s.T())
-	defer ctrl.Finish()
-
-	virtualServer := repositories.NewVirtualServer("virtualServer", "Virtual Server")
-	virtualServerRepository := mocks.NewMockVirtualServerRepository(ctrl)
-	virtualServerRepository.EXPECT().FirstOrErr(gomock.Any(), gomock.Any()).Return(virtualServer, nil)
-
-	project := repositories.NewProject(virtualServer.Id(), "project", "Project", "Test Project")
-	projectRepository := mocks.NewMockProjectRepository(ctrl)
-	projectRepository.EXPECT().FirstOrErr(gomock.Any(), gomock.Any()).Return(project, nil)
-
-	roleRepository := mocks.NewMockRoleRepository(ctrl)
-	roleRepository.EXPECT().FirstOrErr(gomock.Any(), gomock.Any()).Return(nil, errors.New("error"))
-
-	ctx := s.createContext(ctrl, virtualServerRepository, projectRepository, roleRepository)
-	cmd := PatchRole{}
-
-	// act
-	resp, err := HandlePatchRole(ctx, cmd)
+	resp, err := HandleDeleteRole(ctx, cmd)
 
 	// assert
 	s.Require().Error(err)
 	s.Nil(resp)
 }
 
-func (s *PatchRoleCommandSuite) TestProjectError() {
+func (s *DeleteRoleCommandSuite) TestProjectError() {
 	// arrange
 	ctrl := gomock.NewController(s.T())
 	defer ctrl.Finish()
@@ -150,42 +94,60 @@ func (s *PatchRoleCommandSuite) TestProjectError() {
 	projectRepository.EXPECT().FirstOrErr(gomock.Any(), gomock.Any()).Return(nil, errors.New("error"))
 
 	ctx := s.createContext(ctrl, virtualServerRepository, projectRepository, nil)
-	cmd := PatchRole{}
+	cmd := DeleteRole{}
 
 	// act
-	resp, err := HandlePatchRole(ctx, cmd)
+	resp, err := HandleDeleteRole(ctx, cmd)
 
 	// assert
 	s.Require().Error(err)
 	s.Nil(resp)
 }
 
-func (s *PatchRoleCommandSuite) TestVirtualServerError() {
+func (s *DeleteRoleCommandSuite) TestHappyPath() {
 	// arrange
 	ctrl := gomock.NewController(s.T())
 	defer ctrl.Finish()
 
-	virtualServerRepository := mocks.NewMockVirtualServerRepository(ctrl)
-	virtualServerRepository.EXPECT().FirstOrErr(gomock.Any(), gomock.Any()).Return(nil, errors.New("error"))
+	now := time.Now()
 
-	ctx := s.createContext(ctrl, virtualServerRepository, nil, nil)
-	cmd := PatchRole{}
+	virtualServer := repositories.NewVirtualServer("virtualServer", "Virtual Server")
+	virtualServer.Mock(now)
+	virtualServerRepository := mocks.NewMockVirtualServerRepository(ctrl)
+	virtualServerRepository.EXPECT().FirstOrErr(gomock.Any(), gomock.Any()).Return(virtualServer, nil)
+
+	project := repositories.NewProject(virtualServer.Id(), "project", "Project", "Test Project")
+	project.Mock(now)
+	projectRepository := mocks.NewMockProjectRepository(ctrl)
+	projectRepository.EXPECT().FirstOrErr(gomock.Any(), gomock.Any()).Return(project, nil)
+
+	role := repositories.NewRole(virtualServer.Id(), project.Id(), "role", "description")
+	role.Mock(now)
+	roleRepository := mocks.NewMockRoleRepository(ctrl)
+	roleRepository.EXPECT().FirstOrNil(gomock.Any(), gomock.Any()).Return(role, nil)
+	roleRepository.EXPECT().Delete(role.Id())
+
+	ctx := s.createContext(ctrl, virtualServerRepository, projectRepository, roleRepository)
+	cmd := DeleteRole{
+		VirtualServerName: virtualServer.Name(),
+		ProjectSlug:       project.Slug(),
+		RoleId:            role.Id(),
+	}
 
 	// act
-	resp, err := HandlePatchRole(ctx, cmd)
+	resp, err := HandleDeleteRole(ctx, cmd)
 
 	// assert
-	s.Require().Error(err)
-	s.Nil(resp)
+	s.Require().NoError(err)
+	s.NotNil(resp)
 }
 
-// TestSystemProjectRequiresSystemUser pins down the gate that mirrors
-// CreateRole's existing system-project guard. Renaming a role inside the
-// system project is the very thing that lets a VirtualServerAdmin self-
-// promote to SystemAdmin (the JWT `system:<roleName>` claim binds the
-// role's current name to roles.AllRoles), so PatchRole MUST refuse the
-// change when the caller lacks the SystemUser permission.
-func (s *PatchRoleCommandSuite) TestSystemProjectRequiresSystemUser() {
+// TestSystemProjectRequiresSystemUser pins down the same system-project
+// guard as PatchRole. Deleting the system-project `admin` role would
+// brick admin functionality, and deleting `system-admin` would let an
+// attacker demote legitimate operators -- both are privileged operations
+// that must require the SystemUser permission, matching CreateRole.
+func (s *DeleteRoleCommandSuite) TestSystemProjectRequiresSystemUser() {
 	// arrange
 	ctrl := gomock.NewController(s.T())
 	defer ctrl.Finish()
@@ -207,15 +169,14 @@ func (s *PatchRoleCommandSuite) TestSystemProjectRequiresSystemUser() {
 	ctx := s.createContext(ctrl, virtualServerRepository, projectRepository, nil)
 	ctx = authentication.ContextWithCurrentUser(ctx, authentication.NewCurrentUser(uuid.New()))
 
-	cmd := PatchRole{
+	cmd := DeleteRole{
 		VirtualServerName: virtualServer.Name(),
 		ProjectSlug:       project.Slug(),
 		RoleId:            uuid.New(),
-		Name:              utils.Ptr("system-admin"),
 	}
 
 	// act
-	resp, err := HandlePatchRole(ctx, cmd)
+	resp, err := HandleDeleteRole(ctx, cmd)
 
 	// assert
 	s.Require().Error(err)
@@ -223,10 +184,7 @@ func (s *PatchRoleCommandSuite) TestSystemProjectRequiresSystemUser() {
 	s.Require().ErrorIs(err, utils.ErrHttpUnauthorized)
 }
 
-// TestSystemProjectAllowedForSystemUser proves the guard does not break
-// the legitimate path: the system identity (used for internal bootstrap
-// flows) can still patch system-project roles.
-func (s *PatchRoleCommandSuite) TestSystemProjectAllowedForSystemUser() {
+func (s *DeleteRoleCommandSuite) TestSystemProjectAllowedForSystemUser() {
 	// arrange
 	ctrl := gomock.NewController(s.T())
 	defer ctrl.Finish()
@@ -246,23 +204,20 @@ func (s *PatchRoleCommandSuite) TestSystemProjectAllowedForSystemUser() {
 	role := repositories.NewRole(virtualServer.Id(), project.Id(), "admin", "Administrator role")
 	role.Mock(now)
 	roleRepository := mocks.NewMockRoleRepository(ctrl)
-	roleRepository.EXPECT().FirstOrErr(gomock.Any(), gomock.Any()).Return(role, nil)
-	roleRepository.EXPECT().Update(gomock.Cond(func(x *repositories.Role) bool {
-		return x.Name() == "renamed"
-	}))
+	roleRepository.EXPECT().FirstOrNil(gomock.Any(), gomock.Any()).Return(role, nil)
+	roleRepository.EXPECT().Delete(role.Id())
 
 	ctx := s.createContext(ctrl, virtualServerRepository, projectRepository, roleRepository)
 	ctx = authentication.ContextWithCurrentUser(ctx, authentication.SystemUser())
 
-	cmd := PatchRole{
+	cmd := DeleteRole{
 		VirtualServerName: virtualServer.Name(),
 		ProjectSlug:       project.Slug(),
 		RoleId:            role.Id(),
-		Name:              utils.Ptr("renamed"),
 	}
 
 	// act
-	resp, err := HandlePatchRole(ctx, cmd)
+	resp, err := HandleDeleteRole(ctx, cmd)
 
 	// assert
 	s.Require().NoError(err)

--- a/internal/commands/PatchRole.go
+++ b/internal/commands/PatchRole.go
@@ -3,11 +3,13 @@ package commands
 import (
 	"context"
 	"fmt"
+	"github.com/The127/Keyline/internal/authentication"
 	"github.com/The127/Keyline/internal/authentication/permissions"
 	"github.com/The127/Keyline/internal/behaviours"
 	"github.com/The127/Keyline/internal/database"
 	"github.com/The127/Keyline/internal/middlewares"
 	"github.com/The127/Keyline/internal/repositories"
+	"github.com/The127/Keyline/utils"
 
 	"github.com/The127/ioc"
 
@@ -56,6 +58,21 @@ func HandlePatchRole(ctx context.Context, command PatchRole) (*PatchRoleResponse
 	project, err := dbContext.Projects().FirstOrErr(ctx, projectFilter)
 	if err != nil {
 		return nil, fmt.Errorf("getting project: %w", err)
+	}
+
+	// System-project roles map to privileged identities through the JWT
+	// `system:<roleName>` claim (AuthenticationMiddleware honours those
+	// directly via roles.AllRoles). Mutating one of these — name or
+	// description — is the same trust decision as creating one and
+	// requires the same gate that CreateRole enforces. Without it, any
+	// caller with RoleUpdate (i.e. every VS admin) can rename the
+	// `admin` role to `system-admin` and silently promote every holder
+	// of that role to SystemAdmin permissions on next login.
+	if project.SystemProject() {
+		currentUser := authentication.GetCurrentUser(ctx)
+		if !currentUser.HasPermission(permissions.SystemUser).IsSuccess() {
+			return nil, fmt.Errorf("modifying roles in system project requires system user permission: %w", utils.ErrHttpUnauthorized)
+		}
 	}
 
 	roleFilter := repositories.NewRoleFilter().

--- a/tests/e2e/patchrolesystemproject_test.go
+++ b/tests/e2e/patchrolesystemproject_test.go
@@ -1,0 +1,152 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"errors"
+
+	"github.com/The127/Keyline/api"
+	"github.com/The127/Keyline/client"
+	"github.com/The127/Keyline/config"
+	"github.com/The127/Keyline/utils"
+
+	"github.com/google/uuid"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// systemProjectSlug must match repositories.NewSystemProject's hard-coded
+// "system" slug; encoded here so a rename of that constant trips the test
+// instead of silently passing.
+const systemProjectSlug = "system"
+
+// findRoleId locates a role in the given project by name via the role
+// listing endpoint. The harness's default service user holds the `admin`
+// role (VirtualServerAdmin) and so has RoleView in any project.
+func findRoleId(h *harness, projectSlug, roleName string) uuid.UUID {
+	roles, err := h.Client().Project().Role(projectSlug).List(h.Ctx(), client.ListRoleParams{
+		Page: 0,
+		Size: 100,
+	})
+	Expect(err).ToNot(HaveOccurred())
+	for _, r := range roles.Items {
+		if r.Name == roleName {
+			return r.Id
+		}
+	}
+	Fail("role '" + roleName + "' not found in project '" + projectSlug + "'")
+	return uuid.Nil
+}
+
+func init() {
+	for _, backend := range testBackends {
+		backend := backend
+		Describe("PatchRole / DeleteRole system-project guard ["+backend.name+"]", Ordered, func() {
+			var h *harness
+
+			BeforeAll(func() {
+				if backend.dbMode == config.DatabaseModePostgres && !postgresBackendAvailable() {
+					Skip("Postgres not available")
+				}
+				// The harness's default service user has only the system
+				// project's `admin` role -- exactly the attacker profile
+				// for this bug: VirtualServerAdmin trying to mutate a
+				// privileged role-name.
+				h = newE2eTestHarness(backend.dbMode, serviceUserTokenSource)
+			})
+
+			AfterAll(func() {
+				if h != nil {
+					h.Close()
+				}
+			})
+
+			It("refuses PatchRole on a system-project role for a non-system caller (the bypass)", func() {
+				adminRoleId := findRoleId(h, systemProjectSlug, "admin")
+
+				err := h.Client().Project().Role(systemProjectSlug).Patch(
+					h.Ctx(),
+					adminRoleId,
+					api.PatchRoleRequestDto{Name: utils.Ptr("system-admin")},
+				)
+				Expect(err).To(HaveOccurred())
+
+				var apiErr client.ApiError
+				Expect(errors.As(err, &apiErr)).To(BeTrue(), "expected client.ApiError, got %T: %v", err, err)
+				Expect(apiErr.Code).To(Equal(401),
+					"PatchRole on system project must be rejected with 401 -- "+
+						"otherwise an admin can rename `admin` to `system-admin` "+
+						"and self-promote to SystemAdmin via the JWT roles claim")
+
+				// Verify the database state was not mutated: the role's
+				// name must still be `admin`. (If the rename had taken
+				// effect, the harness's service user would have started
+				// claiming system:system-admin in its JWTs and gained
+				// VirtualServerCreate.)
+				role, err := h.Client().Project().Role(systemProjectSlug).Get(h.Ctx(), adminRoleId)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(role.Name).To(Equal("admin"))
+			})
+
+			It("refuses DeleteRole on a system-project role for a non-system caller", func() {
+				adminRoleId := findRoleId(h, systemProjectSlug, "admin")
+
+				err := h.Client().Project().Role(systemProjectSlug).Delete(h.Ctx(), adminRoleId)
+				Expect(err).To(HaveOccurred())
+
+				var apiErr client.ApiError
+				Expect(errors.As(err, &apiErr)).To(BeTrue(), "expected client.ApiError, got %T: %v", err, err)
+				Expect(apiErr.Code).To(Equal(401))
+
+				// Role must still exist.
+				role, err := h.Client().Project().Role(systemProjectSlug).Get(h.Ctx(), adminRoleId)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(role.Name).To(Equal("admin"))
+			})
+
+			It("still allows PatchRole on a non-system project role (regression check)", func() {
+				// Create a fresh project + role belonging to it. The harness
+				// admin has ProjectCreate / RoleCreate / RoleUpdate.
+				projResp, err := h.Client().Project().Create(h.Ctx(), api.CreateProjectRequestDto{
+					Slug:        "non-system-project-" + backend.name,
+					Name:        "Non System Project",
+					Description: "Non-system project for the PatchRole guard regression test.",
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(projResp.Id).ToNot(BeZero())
+
+				roleResp, err := h.Client().Project().Role("non-system-project-" + backend.name).Create(h.Ctx(), api.CreateRoleRequestDto{
+					Name:        "rename-me",
+					Description: "Role for the rename regression check.",
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(roleResp.Id).ToNot(BeZero())
+
+				err = h.Client().Project().Role("non-system-project-" + backend.name).Patch(
+					h.Ctx(),
+					roleResp.Id,
+					api.PatchRoleRequestDto{Name: utils.Ptr("renamed")},
+				)
+				Expect(err).ToNot(HaveOccurred(),
+					"the system-project guard must NOT fire on non-system projects")
+
+				role, err := h.Client().Project().Role("non-system-project-" + backend.name).Get(h.Ctx(), roleResp.Id)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(role.Name).To(Equal("renamed"))
+			})
+
+			It("still allows DeleteRole on a non-system project role (regression check)", func() {
+				roleResp, err := h.Client().Project().Role("non-system-project-" + backend.name).Create(h.Ctx(), api.CreateRoleRequestDto{
+					Name:        "delete-me",
+					Description: "Role for the delete regression check.",
+				})
+				Expect(err).ToNot(HaveOccurred())
+
+				err = h.Client().Project().Role("non-system-project-" + backend.name).Delete(h.Ctx(), roleResp.Id)
+				Expect(err).ToNot(HaveOccurred(),
+					"the system-project guard must NOT fire on non-system projects")
+			})
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- A user with `RoleUpdate` (any VS admin) could PATCH the system-project `admin` role and rename it to `system-admin`. Role assignments are keyed by `role_id`, so the attacker's existing assignment then maps to a role named `system-admin`. Their next access-token's `roles` claim becomes `system:system-admin`, the `AuthenticationMiddleware` look-up via `roles.AllRoles[SystemAdmin]` grants `VirtualServerCreate`, and on the initial VS the attacker can spin up new VSes — a privilege the `VirtualServerAdmin` role never had.
- `CreateRole` already enforces the system-project / `SystemUser` gate (`internal/commands/CreateRole.go:65-71`); the sibling commands `PatchRole` and `DeleteRole`, added later, were missing it. Same trust decision, same gate now applied to all three CRUD paths.
- Same shape closes a smaller `DeleteRole` issue: a VS admin could also delete the system-project `admin` role (bricking VS admin functionality) or the `system-admin` role (demoting legitimate operators).

## What changed

- `internal/commands/PatchRole.go` — added the system-project / `SystemUser` guard immediately after the project lookup; mirrors `CreateRole.go:65-71`. Imports `internal/authentication` and `utils`.
- `internal/commands/DeleteRole.go` — same guard, same shape, same imports.
- `internal/commands/PatchRole_test.go` — adds `TestSystemProjectRequiresSystemUser` and `TestSystemProjectAllowedForSystemUser`.
- `internal/commands/DeleteRole_test.go` — new file, mirrors PatchRole's test surface (`TestVirtualServerError`, `TestProjectError`, `TestHappyPath`, `TestSystemProjectRequiresSystemUser`, `TestSystemProjectAllowedForSystemUser`).
- `tests/e2e/patchrolesystemproject_test.go` — Ginkgo e2e suite (`e2e` build tag), runs against both backends. Four `It`s: PatchRole on system project denied with 401, DeleteRole on system project denied with 401, PatchRole on a non-system project still allowed, DeleteRole on a non-system project still allowed.

## Compatibility notes

The system project's roles were not intended to be mutable from HTTP — `CreateRole` was already locked down. `PatchRole` and `DeleteRole` against `/projects/system/...` will now return `401 modifying roles in system project requires system user permission: unauthorized` (or the equivalent delete message) for any caller without `SystemUser`. Internal flows that act under `authentication.SystemUser()` (e.g. `CreateVirtualServer` bootstrap) are unaffected, and operations on roles in any non-system project are unchanged. No HTTP API surface is added or removed.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/handlers/ ./internal/commands/` — passes, includes the new unit tests for `HandlePatchRole` / `HandleDeleteRole` system-project denial and SystemUser-allowed paths.
- [x] `go test -tags=e2e ./tests/e2e/` — passes; the new `PatchRole / DeleteRole system-project guard` describe block runs 8 specs (4 cases × 2 backends).
- [x] `golangci-lint run ./...` — 0 issues.
- [x] PoC re-run end to end (`security_issues/patch-role-system-project-escalation/`): pre-fix it confirms the privilege escalation; post-fix it confirms the PATCH is rejected with the new error, the post-rename `POST /api/virtual-servers` is still 401 (no leak), and the non-system-project rename still returns 204.

## Out of scope

- `AssignRoleToUser` against system-project roles (a regular admin can self-assign a pre-existing `system-admin` role on the initial VS, where that role is created by default via `CreateSystemAdminRole=true`). Same family of weakness, different command path; warrants a separate audit pass to decide whether self-assignment of system-project roles should also gate on `SystemUser`. Not addressed in this PR.
- `AuthenticationMiddleware` cross-VS fallback policy (token from initial VS honoured on every other VS): intended behaviour for system-admin tokens, but worth documenting more tightly.
- `mapClaims` fetches role assignments without a virtual-server filter (the existing `// TODO: add virtual server filter`). Not exploitable today because `AssignRoleToUser` already constrains assignments to a single VS, but a defence-in-depth follow-up.