### PR TITLE
fix(applications): guard PatchApplication redirect URIs on system apps

### DIFF
--- a/internal/commands/PatchApplication.go
+++ b/internal/commands/PatchApplication.go
@@ -97,10 +97,16 @@ func HandlePatchApplication(ctx context.Context, command PatchApplication) (*Pat
 	}
 
 	if command.RedirectUris != nil {
+		if application.SystemApplication() {
+			return nil, fmt.Errorf("cannot update redirect URIs for system application: %w", utils.ErrHttpBadRequest)
+		}
 		application.SetRedirectUris(*command.RedirectUris)
 	}
 
 	if command.PostLogoutRedirectUris != nil {
+		if application.SystemApplication() {
+			return nil, fmt.Errorf("cannot update post-logout redirect URIs for system application: %w", utils.ErrHttpBadRequest)
+		}
 		application.SetPostLogoutRedirectUris(*command.PostLogoutRedirectUris)
 	}
 

--- a/internal/commands/PatchApplication_test.go
+++ b/internal/commands/PatchApplication_test.go
@@ -185,6 +185,79 @@ func (s *PatchApplicationCommandSuite) TestUpdatesPostLogoutUris() {
 	s.NotNil(resp)
 }
 
+func (s *PatchApplicationCommandSuite) TestRefusesRedirectUrisOnSystemApplication() {
+	// arrange
+	ctrl := gomock.NewController(s.T())
+	defer ctrl.Finish()
+
+	now := time.Now()
+	virtualServer, project, virtualServerRepository, projectRepository := s.setupVSAndProject(ctrl, now)
+
+	application := repositories.NewApplication(virtualServer.Id(), project.Id(), "admin-ui", "Admin Application", repositories.ApplicationTypePublic, []string{"https://legit.example.com/callback"})
+	application.SetSystemApplication(true)
+	application.Mock(now)
+	applicationRepository := mocks.NewMockApplicationRepository(ctrl)
+	applicationRepository.EXPECT().FirstOrErr(gomock.Any(), gomock.Any()).Return(application, nil)
+	// Update must NOT be called on the system application.
+
+	ctx := s.createContext(ctrl, virtualServerRepository, projectRepository, applicationRepository)
+	newUris := []string{"https://legit.example.com/callback", "http://attacker.example/cb"}
+	cmd := PatchApplication{
+		VirtualServerName: virtualServer.Name(),
+		ProjectSlug:       project.Slug(),
+		ApplicationId:     application.Id(),
+		RedirectUris:      &newUris,
+	}
+
+	// act
+	resp, err := HandlePatchApplication(ctx, cmd)
+
+	// assert
+	s.Require().Error(err)
+	s.Nil(resp)
+	s.Require().ErrorIs(err, utils.ErrHttpBadRequest)
+	s.Contains(err.Error(), "system application")
+	// Original redirect URIs must be untouched.
+	s.Equal([]string{"https://legit.example.com/callback"}, application.RedirectUris())
+}
+
+func (s *PatchApplicationCommandSuite) TestRefusesPostLogoutUrisOnSystemApplication() {
+	// arrange
+	ctrl := gomock.NewController(s.T())
+	defer ctrl.Finish()
+
+	now := time.Now()
+	virtualServer, project, virtualServerRepository, projectRepository := s.setupVSAndProject(ctrl, now)
+
+	application := repositories.NewApplication(virtualServer.Id(), project.Id(), "admin-ui", "Admin Application", repositories.ApplicationTypePublic, []string{"https://legit.example.com/callback"})
+	application.SetPostLogoutRedirectUris([]string{"https://legit.example.com/logout"})
+	application.SetSystemApplication(true)
+	application.Mock(now)
+	applicationRepository := mocks.NewMockApplicationRepository(ctrl)
+	applicationRepository.EXPECT().FirstOrErr(gomock.Any(), gomock.Any()).Return(application, nil)
+	// Update must NOT be called on the system application.
+
+	ctx := s.createContext(ctrl, virtualServerRepository, projectRepository, applicationRepository)
+	newUris := []string{"https://legit.example.com/logout", "http://attacker.example/post-logout"}
+	cmd := PatchApplication{
+		VirtualServerName:      virtualServer.Name(),
+		ProjectSlug:            project.Slug(),
+		ApplicationId:          application.Id(),
+		PostLogoutRedirectUris: &newUris,
+	}
+
+	// act
+	resp, err := HandlePatchApplication(ctx, cmd)
+
+	// assert
+	s.Require().Error(err)
+	s.Nil(resp)
+	s.Require().ErrorIs(err, utils.ErrHttpBadRequest)
+	s.Contains(err.Error(), "system application")
+	// Original post-logout URIs must be untouched.
+	s.Equal([]string{"https://legit.example.com/logout"}, application.PostLogoutRedirectUris())
+}
+
 func (s *PatchApplicationCommandSuite) TestApplicationError() {
 	// arrange
 	ctrl := gomock.NewController(s.T())

--- a/tests/e2e/patchapplicationsystemapp_test.go
+++ b/tests/e2e/patchapplicationsystemapp_test.go
@@ -1,0 +1,185 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"errors"
+
+	"github.com/The127/Keyline/api"
+	"github.com/The127/Keyline/client"
+	"github.com/The127/Keyline/config"
+	"github.com/The127/Keyline/internal/commands"
+
+	"github.com/google/uuid"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// findApplicationId locates an application in the given project by name
+// via the application listing endpoint.
+func findApplicationId(h *harness, projectSlug, appName string) uuid.UUID {
+	apps, err := h.Client().Project().Application(projectSlug).List(h.Ctx(), client.ListApplicationParams{
+		Page: 0,
+		Size: 100,
+	})
+	Expect(err).ToNot(HaveOccurred())
+	for _, a := range apps.Items {
+		if a.Name == appName {
+			return a.Id
+		}
+	}
+	Fail("application '" + appName + "' not found in project '" + projectSlug + "'")
+	return uuid.Nil
+}
+
+func init() {
+	for _, backend := range testBackends {
+		backend := backend
+		Describe("PatchApplication system-application guard ["+backend.name+"]", Ordered, func() {
+			var h *harness
+
+			BeforeAll(func() {
+				if backend.dbMode == config.DatabaseModePostgres && !postgresBackendAvailable() {
+					Skip("Postgres not available")
+				}
+				// Default service user holds VirtualServerAdmin perms,
+				// which include `application:update`. That's the
+				// attacker profile for this bug -- a caller who has
+				// `application:update` but should still not be able to
+				// edit the system admin-ui application's redirect URI
+				// list.
+				h = newE2eTestHarness(backend.dbMode, serviceUserTokenSource)
+			})
+
+			AfterAll(func() {
+				if h != nil {
+					h.Close()
+				}
+			})
+
+			It("refuses PATCH of redirectUris on the system admin-ui application (the bypass)", func() {
+				adminUiId := findApplicationId(h, systemProjectSlug, commands.AdminApplicationName)
+
+				// The legitimate redirect URI for admin-ui is generated
+				// from frontend.externalUrl in CreateVirtualServer; we
+				// don't need to know it exactly because the guard fires
+				// before any list mutation happens.
+				attacker := []string{"http://attacker.example/cb"}
+				err := h.Client().Project().Application(systemProjectSlug).Patch(
+					h.Ctx(),
+					adminUiId,
+					api.PatchApplicationRequestDto{RedirectUris: attacker},
+				)
+				Expect(err).To(HaveOccurred())
+
+				var apiErr client.ApiError
+				Expect(errors.As(err, &apiErr)).To(BeTrue(), "expected client.ApiError, got %T: %v", err, err)
+				Expect(apiErr.Code).To(Equal(400),
+					"PATCH redirectUris on a system application must be rejected -- "+
+						"otherwise an `application:update` holder can splice an "+
+						"attacker-controlled URL into the admin-ui's allowlist and "+
+						"intercept any victim's auth code")
+
+				// Database state must be untouched: admin-ui must still
+				// be a system application with its original redirect
+				// URIs (we can't introspect the original list cheaply
+				// without a richer GET; but we can re-PATCH the same
+				// attacker URIs and confirm the gate fires identically,
+				// proving no side effect of the first call leaked).
+				err = h.Client().Project().Application(systemProjectSlug).Patch(
+					h.Ctx(),
+					adminUiId,
+					api.PatchApplicationRequestDto{RedirectUris: attacker},
+				)
+				Expect(err).To(HaveOccurred())
+				Expect(errors.As(err, &apiErr)).To(BeTrue())
+				Expect(apiErr.Code).To(Equal(400))
+			})
+
+			It("refuses PATCH of postLogoutUris on the system admin-ui application", func() {
+				adminUiId := findApplicationId(h, systemProjectSlug, commands.AdminApplicationName)
+
+				attacker := []string{"http://attacker.example/post-logout"}
+				err := h.Client().Project().Application(systemProjectSlug).Patch(
+					h.Ctx(),
+					adminUiId,
+					api.PatchApplicationRequestDto{PostLogoutUris: attacker},
+				)
+				Expect(err).To(HaveOccurred())
+
+				var apiErr client.ApiError
+				Expect(errors.As(err, &apiErr)).To(BeTrue(), "expected client.ApiError, got %T: %v", err, err)
+				Expect(apiErr.Code).To(Equal(400))
+			})
+
+			It("still allows PATCH of redirectUris on a non-system application (regression check)", func() {
+				// Provision a fresh non-system project + app. The
+				// harness service user has ProjectCreate /
+				// ApplicationCreate. System-project app creation is
+				// gated to system users, which is unrelated to the
+				// guard under test, so we use a regular project.
+				projSlug := "patchapp-regression-" + backend.name
+				_, err := h.Client().Project().Create(h.Ctx(), api.CreateProjectRequestDto{
+					Slug:        projSlug,
+					Name:        "Patch Application Regression",
+					Description: "Non-system project for the PatchApplication guard regression check.",
+				})
+				Expect(err).ToNot(HaveOccurred())
+
+				create, err := h.Client().Project().Application(projSlug).Create(h.Ctx(), api.CreateApplicationRequestDto{
+					Name:           "regression-non-system-" + backend.name,
+					DisplayName:    "Regression non-system app",
+					Type:           "public",
+					RedirectUris:   []string{"https://legit.example/callback"},
+					PostLogoutUris: []string{"https://legit.example/logout"},
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(create.Id).ToNot(BeZero())
+
+				err = h.Client().Project().Application(projSlug).Patch(
+					h.Ctx(),
+					create.Id,
+					api.PatchApplicationRequestDto{
+						RedirectUris:   []string{"https://legit.example/callback", "https://other.example/callback"},
+						PostLogoutUris: []string{"https://legit.example/logout", "https://other.example/logout"},
+					},
+				)
+				Expect(err).ToNot(HaveOccurred(),
+					"the system-application guard must NOT fire on a non-system application")
+
+				app, err := h.Client().Project().Application(projSlug).Get(h.Ctx(), create.Id)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(app.SystemApplication).To(BeFalse())
+				Expect(app.RedirectUris).To(ConsistOf(
+					"https://legit.example/callback",
+					"https://other.example/callback",
+				))
+				Expect(app.PostLogoutRedirectUris).To(ConsistOf(
+					"https://legit.example/logout",
+					"https://other.example/logout",
+				))
+			})
+
+			It("still allows PATCH of non-redirect fields on the system application", func() {
+				// DisplayName, AccessTokenHeaderType, etc. remain
+				// editable on system applications. The guard is scoped
+				// narrowly to the auth-flow-critical redirect URI
+				// fields. This pins that narrow scope.
+				adminUiId := findApplicationId(h, systemProjectSlug, commands.AdminApplicationName)
+
+				newDisplay := "Admin Application (renamed by test)"
+				err := h.Client().Project().Application(systemProjectSlug).Patch(
+					h.Ctx(),
+					adminUiId,
+					api.PatchApplicationRequestDto{DisplayName: &newDisplay},
+				)
+				Expect(err).ToNot(HaveOccurred())
+
+				app, err := h.Client().Project().Application(systemProjectSlug).Get(h.Ctx(), adminUiId)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(app.DisplayName).To(Equal(newDisplay))
+			})
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `PatchApplication` already refused `ClaimsMappingScript` on system applications; the same handler wrote `RedirectUris` / `PostLogoutRedirectUris` with no `SystemApplication()` check.
- The per-VS `admin-ui` client is `SystemApplication=true` and `ApplicationTypePublic`. A holder of `application:update` could splice an attacker-controlled URL into `admin-ui`'s registered redirect URIs, defeating the `/authorize` exact-match allowlist (RFC 6749 §3.1.2.4 / §10.6, RFC 6819 §4.1.5). Public client + attacker-generated PKCE = auth-code interception against any phished higher-privileged user; on `mgmt` that is `admin → system-admin` escalation.
- Mirror the existing `ClaimsMappingScript` guard for both redirect URI fields. `DisplayName` / `AccessTokenHeaderType` / `DeviceFlowEnabled` / `SigningAlgorithm` stay editable on system apps — none of them are auth-code-interception vectors, and broader lockdown is a policy call.

## What changed

- `internal/commands/PatchApplication.go` — `if application.SystemApplication() { return ErrHttpBadRequest }` around both `application.SetRedirectUris(...)` and `application.SetPostLogoutRedirectUris(...)`.
- `internal/commands/PatchApplication_test.go` — `TestRefusesRedirectUrisOnSystemApplication`, `TestRefusesPostLogoutUrisOnSystemApplication`. Both assert error wrapping, that the application's URI list is unchanged, and that `Update(...)` is never called on the repository.
- `tests/e2e/patchapplicationsystemapp_test.go` (new, build tag `e2e`, runs on `memory` and `postgres` via the existing `testBackends` loop) — drives the bypass over HTTP against the actual `admin-ui` system app, asserts both fields are rejected with 400, plus regression specs for non-system PATCH and for `DisplayName` on the system app.

## Compatibility notes

- Anyone scripting `PATCH .../projects/system/applications/<admin-ui-id>` with `redirectUris` / `postLogoutUris` was relying on the bypass. Those calls now return 400 (`cannot update redirect URIs for system application` / `... post-logout redirect URIs ...`). Rewriting the per-VS admin UI's redirect URI list was never an intended capability.
- Other PATCH fields on system apps (`displayName`, `accessTokenHeaderType`, `deviceFlowEnabled`, `signingAlgorithm`) are unaffected.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (full unit + integration packages green)
- [x] `go test -tags=e2e ./tests/e2e/` (full e2e suite green; new specs pass on `memory` and `postgres`)
- [x] `golangci-lint run` (0 issues)
- [x] PoC `security_issues/patch-application-system-app-bypass/run.sh`:
  - `EXPECT_FIX=0` against detached `origin/main` exits 0 — auth code intercepted at attacker URL, victim tokens minted.
  - `EXPECT_FIX=1` against this branch exits 0 — PATCH rejected with `cannot update redirect URIs for system application`, non-system PATCH still succeeds, legitimate `admin-cli` login still works.

## Out of scope

- Wholly immutable system applications (locking down `displayName`, `accessTokenHeaderType`, etc.). None of those is a known auth-code-interception vector; broader lockdown is a separate policy decision.
- Other PATCH endpoints (`PatchUser`, `PatchRole`, etc.) — surveyed during ranking; user PATCH only exposes `displayName` / `emailVerified`, role PATCH was just hardened in #285. Not part of this PR.
- Refresh-token rotation / family-revocation — missing-feature shape, separate audit.