### PR TITLE
fix(roles): guard AssignRoleToUser on the system project

### DIFF
--- a/internal/commands/AssignRoleToUser.go
+++ b/internal/commands/AssignRoleToUser.go
@@ -3,11 +3,13 @@ package commands
 import (
 	"context"
 	"fmt"
+	"github.com/The127/Keyline/internal/authentication"
 	"github.com/The127/Keyline/internal/authentication/permissions"
 	"github.com/The127/Keyline/internal/behaviours"
 	"github.com/The127/Keyline/internal/database"
 	"github.com/The127/Keyline/internal/middlewares"
 	"github.com/The127/Keyline/internal/repositories"
+	"github.com/The127/Keyline/utils"
 
 	"github.com/The127/ioc"
 
@@ -53,6 +55,22 @@ func HandleAssignRoleToUser(ctx context.Context, command AssignRoleToUser) (*Ass
 	project, err := dbContext.Projects().FirstOrErr(ctx, projectFilter)
 	if err != nil {
 		return nil, fmt.Errorf("getting project: %w", err)
+	}
+
+	// Role assignments inside the system project drive the JWT
+	// `system:<roleName>` claim that AuthenticationMiddleware honours
+	// directly via roles.AllRoles. Granting one is the same trust
+	// decision as creating, renaming, or deleting one (see
+	// CreateRole / PatchRole / DeleteRole) and requires the same
+	// gate. Without it, any caller with RoleAssign (i.e. every VS
+	// admin) could assign the system-project `system-admin` role to
+	// themselves on the initial VS and silently promote to
+	// SystemAdmin permissions on next login.
+	if project.SystemProject() {
+		currentUser := authentication.GetCurrentUser(ctx)
+		if !currentUser.HasPermission(permissions.SystemUser).IsSuccess() {
+			return nil, fmt.Errorf("assigning roles in system project requires system user permission: %w", utils.ErrHttpUnauthorized)
+		}
 	}
 
 	roleFilter := repositories.NewRoleFilter().

--- a/internal/commands/AssignRoleToUser_test.go
+++ b/internal/commands/AssignRoleToUser_test.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"errors"
+	"github.com/The127/Keyline/internal/authentication"
 	"github.com/The127/Keyline/internal/database"
 	"github.com/The127/Keyline/internal/middlewares"
 	"github.com/The127/Keyline/internal/mocks"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/The127/ioc"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 )
@@ -173,6 +175,104 @@ func (s *AssignRoleToUserCommandSuite) TestUserError() {
 
 	// assert
 	s.Error(err)
+}
+
+// TestSystemProjectRequiresSystemUser pins down the gate that mirrors
+// CreateRole / PatchRole / DeleteRole. The persisted (user_id, role_id)
+// row drives the JWT `system:<roleName>` claim that
+// AuthenticationMiddleware honours via roles.AllRoles. Granting a
+// system-project role is the same trust decision as creating, renaming,
+// or deleting one and MUST refuse a non-SystemUser caller.
+func (s *AssignRoleToUserCommandSuite) TestSystemProjectRequiresSystemUser() {
+	// arrange
+	ctrl := gomock.NewController(s.T())
+	defer ctrl.Finish()
+
+	now := time.Now()
+
+	virtualServer := repositories.NewVirtualServer("virtualServer", "Virtual Server")
+	virtualServer.Mock(now)
+	virtualServerRepository := repoMocks.NewMockVirtualServerRepository(ctrl)
+	virtualServerRepository.EXPECT().FirstOrErr(gomock.Any(), gomock.Any()).Return(virtualServer, nil)
+
+	project := repositories.NewSystemProject(virtualServer.Id())
+	project.Mock(now)
+	projectRepository := repoMocks.NewMockProjectRepository(ctrl)
+	projectRepository.EXPECT().FirstOrErr(gomock.Any(), gomock.Any()).Return(project, nil)
+
+	// No Roles() / Users() / UserRoleAssignments() expectations: the
+	// guard must short-circuit before any of those repositories are
+	// touched.
+	ctx := s.createContext(ctrl, virtualServerRepository, projectRepository, nil, nil, nil)
+	ctx = authentication.ContextWithCurrentUser(ctx, authentication.NewCurrentUser(uuid.New()))
+
+	cmd := AssignRoleToUser{
+		VirtualServerName: virtualServer.Name(),
+		ProjectSlug:       project.Slug(),
+		UserId:            uuid.New(),
+		RoleId:            uuid.New(),
+	}
+
+	// act
+	resp, err := HandleAssignRoleToUser(ctx, cmd)
+
+	// assert
+	s.Require().Error(err)
+	s.Nil(resp)
+	s.Require().ErrorIs(err, utils.ErrHttpUnauthorized)
+}
+
+// TestSystemProjectAllowedForSystemUser proves the guard does not
+// break the legitimate path: the system identity (used for internal
+// bootstrap flows) can still assign system-project roles.
+func (s *AssignRoleToUserCommandSuite) TestSystemProjectAllowedForSystemUser() {
+	// arrange
+	ctrl := gomock.NewController(s.T())
+	defer ctrl.Finish()
+
+	now := time.Now()
+
+	virtualServer := repositories.NewVirtualServer("virtualServer", "Virtual Server")
+	virtualServer.Mock(now)
+	virtualServerRepository := repoMocks.NewMockVirtualServerRepository(ctrl)
+	virtualServerRepository.EXPECT().FirstOrErr(gomock.Any(), gomock.Any()).Return(virtualServer, nil)
+
+	project := repositories.NewSystemProject(virtualServer.Id())
+	project.Mock(now)
+	projectRepository := repoMocks.NewMockProjectRepository(ctrl)
+	projectRepository.EXPECT().FirstOrErr(gomock.Any(), gomock.Any()).Return(project, nil)
+
+	role := repositories.NewRole(virtualServer.Id(), project.Id(), "system-admin", "System administrator role")
+	role.Mock(now)
+	roleRepository := repoMocks.NewMockRoleRepository(ctrl)
+	roleRepository.EXPECT().FirstOrErr(gomock.Any(), gomock.Any()).Return(role, nil)
+
+	user := repositories.NewUser("user", "User", "user@mail", virtualServer.Id())
+	user.Mock(now)
+	userRepository := repoMocks.NewMockUserRepository(ctrl)
+	userRepository.EXPECT().FirstOrErr(gomock.Any(), gomock.Any()).Return(user, nil)
+
+	userRoleAssignmentRepository := repoMocks.NewMockUserRoleAssignmentRepository(ctrl)
+	userRoleAssignmentRepository.EXPECT().Insert(gomock.Cond(func(x *repositories.UserRoleAssignment) bool {
+		return x.RoleId() == role.Id() && x.UserId() == user.Id()
+	}))
+
+	ctx := s.createContext(ctrl, virtualServerRepository, projectRepository, roleRepository, userRepository, userRoleAssignmentRepository)
+	ctx = authentication.ContextWithCurrentUser(ctx, authentication.SystemUser())
+
+	cmd := AssignRoleToUser{
+		VirtualServerName: virtualServer.Name(),
+		ProjectSlug:       project.Slug(),
+		UserId:            user.Id(),
+		RoleId:            role.Id(),
+	}
+
+	// act
+	resp, err := HandleAssignRoleToUser(ctx, cmd)
+
+	// assert
+	s.Require().NoError(err)
+	s.NotNil(resp)
 }
 
 func (s *AssignRoleToUserCommandSuite) TestHappyPath() {

--- a/tests/e2e/assignrolesystemproject_test.go
+++ b/tests/e2e/assignrolesystemproject_test.go
@@ -1,0 +1,105 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"errors"
+
+	"github.com/The127/Keyline/api"
+	"github.com/The127/Keyline/client"
+	"github.com/The127/Keyline/config"
+	"github.com/The127/Keyline/utils"
+
+	"github.com/google/uuid"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func init() {
+	for _, backend := range testBackends {
+		backend := backend
+		Describe("AssignRoleToUser system-project guard ["+backend.name+"]", Ordered, func() {
+			var h *harness
+
+			BeforeAll(func() {
+				if backend.dbMode == config.DatabaseModePostgres && !postgresBackendAvailable() {
+					Skip("Postgres not available")
+				}
+				// The harness's default service user has only the system
+				// project's `admin` role -- VirtualServerAdmin perms
+				// (which include RoleAssign) but NOT SystemUser. That is
+				// exactly the attacker profile for this bug: a VS admin
+				// trying to grant a user a privileged system-project
+				// role-name.
+				h = newE2eTestHarness(backend.dbMode, serviceUserTokenSource)
+			})
+
+			AfterAll(func() {
+				if h != nil {
+					h.Close()
+				}
+			})
+
+			It("refuses AssignRoleToUser on a system-project role for a non-system caller (the bypass)", func() {
+				adminRoleId := findRoleId(h, systemProjectSlug, "admin")
+
+				// The caller is the harness service user. We don't even
+				// need its UserId here because the gate must short-circuit
+				// before the user-existence check; an arbitrary uuid is
+				// enough to prove the policy fires.
+				err := h.Client().Project().Role(systemProjectSlug).Assign(
+					h.Ctx(),
+					adminRoleId,
+					uuid.New(),
+				)
+				Expect(err).To(HaveOccurred())
+
+				var apiErr client.ApiError
+				Expect(errors.As(err, &apiErr)).To(BeTrue(), "expected client.ApiError, got %T: %v", err, err)
+				Expect(apiErr.Code).To(Equal(401),
+					"AssignRoleToUser on system project must be rejected with 401 -- "+
+						"otherwise an admin can grant `system-admin` (or any "+
+						"other system-project role) to themselves and self-"+
+						"promote to SystemAdmin via the JWT roles claim")
+			})
+
+			It("still allows AssignRoleToUser on a non-system project role (regression check)", func() {
+				// Set up a fresh project + role that the harness admin can
+				// own. The harness admin has ProjectCreate / RoleCreate /
+				// RoleAssign / UserCreate.
+				projSlug := "non-system-project-assign-" + backend.name
+				_, err := h.Client().Project().Create(h.Ctx(), api.CreateProjectRequestDto{
+					Slug:        projSlug,
+					Name:        "Non System Project Assign",
+					Description: "Non-system project for the AssignRole guard regression test.",
+				})
+				Expect(err).ToNot(HaveOccurred())
+
+				roleResp, err := h.Client().Project().Role(projSlug).Create(h.Ctx(), api.CreateRoleRequestDto{
+					Name:        "assign-me",
+					Description: "Role for the AssignRole regression check.",
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(roleResp.Id).ToNot(BeZero())
+
+				userResp, err := h.Client().User().Create(h.Ctx(), api.CreateUserRequestDto{
+					Username:      "assign-target-" + backend.name,
+					DisplayName:   "Assign Target",
+					Email:         "assign-target-" + backend.name + "@example.com",
+					EmailVerified: utils.Ptr(true),
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(userResp.Id).ToNot(BeZero())
+
+				err = h.Client().Project().Role(projSlug).Assign(
+					h.Ctx(),
+					roleResp.Id,
+					userResp.Id,
+				)
+				Expect(err).ToNot(HaveOccurred(),
+					"the system-project guard must NOT fire on non-system projects")
+			})
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- VirtualServerAdmin → SystemAdmin escalation: any caller with `RoleAssign` could grant the existing `system-admin` role from the system project to themselves on the initial VS, getting `system:system-admin` in their next JWT and unlocking `VirtualServerCreate` (and the rest of the SystemAdmin permission set).
- `AssignRoleToUser` was missing the system-project guard that `CreateRole` / `PatchRole` / `DeleteRole` already enforce (PR #285). Same trust decision, same gate, just the fourth CRUD path that didn't get covered.
- Persisted `(user_id, role_id)` rows drive the `system:<roleName>` claim that `AuthenticationMiddleware` maps to `roles.AllRoles`, so writing the row is exactly the privileged operation that needs the gate.

## What changed

- `internal/commands/AssignRoleToUser.go` — after the project lookup, check `project.SystemProject()` and require the current user to hold `permissions.SystemUser`; return `utils.ErrHttpUnauthorized` BEFORE the role / user lookups so the policy fires without touching the privileged target rows. Mirrors the guard in `CreateRole.go:65-71`, `PatchRole.go:71-76`, and `DeleteRole.go`.
- `internal/commands/AssignRoleToUser_test.go` — `TestSystemProjectRequiresSystemUser` (no Roles/Users/UserRoleAssignments expectations, pinning the short-circuit ordering) and `TestSystemProjectAllowedForSystemUser` (proves the system identity can still drive bootstrap assigns).
- `tests/e2e/assignrolesystemproject_test.go` — new Ginkgo e2e suite, `e2e` build tag, runs on both Postgres and memory backends. Two specs per backend: the bypass (assign on system project denied with 401) and the regression check (assign on a non-system project still 204).

## Compatibility notes

- API-only behaviour change: callers that were previously able to assign system-project roles via `POST /api/virtual-servers/{vs}/projects/system/roles/{roleId}/assign` without holding `SystemUser` will now get 401. The intended path for that operation has always been the bootstrap config (`CreateVirtualServer` seeds the initial admin's system-project role assignments) or an internal `SystemUser`-identity caller. No client of the OIDC flow itself is affected.
- The internal `authentication.SystemUser()` identity (used by bootstrap / mediator-internal calls) still passes the gate, so initial VS provisioning continues to work — covered by `TestSystemProjectAllowedForSystemUser`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/commands/` (unit tests, both new and existing)
- [x] `go test ./...` (full unit suite)
- [x] `go test -tags=e2e ./tests/e2e/` (full e2e suite, postgres + memory)
- [x] `go test -tags=integration ./tests/integration/`
- [x] `golangci-lint run ./...`
- [x] PoC reproducer in `security_issues/assign-role-system-project-escalation/` exits 0 pre-fix (bug present) and exits 0 post-fix with `EXPECT_FIX=1` (gate fires, no privilege leaks, non-system assign still works).

## Out of scope

- Other audit gaps in the broader PATCH-handler review (TODO list captures the remaining ones); this PR is one finding only.
- Refactoring `authenticateApplication` / `roles.AllRoles` mapping to make tenant scoping un-skippable at the type level (separate hardening task).